### PR TITLE
[Bugfix] Replaced `*.shoonyacloud.com` with `*.esper.cloud` in CLI code

### DIFF
--- a/esper/ext/api_client.py
+++ b/esper/ext/api_client.py
@@ -8,7 +8,7 @@ class APIClient:
         self.config = Configuration()
         self.config.api_key['Authorization'] = credential["api_key"]
         self.config.api_key_prefix['Authorization'] = 'Bearer'
-        self.config.host = f"https://{credential['environment']}-api.shoonyacloud.com/api"
+        self.config.host = f"https://{credential['environment']}-api.esper.cloud/api"
 
     def get_enterprise_api_client(self):
         return client.EnterpriseApi(client.ApiClient(self.config))

--- a/esper/ext/remoteadb_api.py
+++ b/esper/ext/remoteadb_api.py
@@ -23,7 +23,7 @@ def get_remoteadb_url(environment: str,
     :return:
     """
 
-    host = f'https://{environment}-api.shoonyacloud.com'
+    host = f'https://{environment}-api.esper.cloud'
     url = f'{host}/api/v0/enterprise/{enterprise_id}/device/{device_id}/remoteadb/'
 
     if remoteadb_id:

--- a/esper/ext/telemetry_api.py
+++ b/esper/ext/telemetry_api.py
@@ -31,7 +31,7 @@ def get_telemetry_url(environment: str,
     :return:
     """
 
-    url = f'https://{environment}-api.shoonyacloud.com/api/graph/{category}/{metric}/?from_time={from_time}&' \
+    url = f'https://{environment}-api.esper.cloud/api/graph/{category}/{metric}/?from_time={from_time}&' \
           f'to_time={to_time}&period={period}&statistic={statistic}&device_id={device_id}&enterprise_id=' \
           f'{enterprise_id}'
 


### PR DESCRIPTION
Issues with newer customers as we are deprecating `*.shoonyacloud.com` domain in favour of the newer `*.esper.cloud` domain.
