### PR TITLE
Add wheel and pip dependencies

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@
 from setuptools import setup, find_packages
 
 
-VERSION = "0.0.12"
+VERSION = "0.0.13"
 
 f = open('README.md', 'r', encoding='utf-8', errors='ignore')
 LONG_DESCRIPTION = f.read()

--- a/setup.py
+++ b/setup.py
@@ -26,6 +26,8 @@ setup(
         espercli = esper.main:main
     """,
     install_requires=[
+        'pip==20.2.4',
+        'wheel',
         'cement==3.0.2',
         'clint>=0.5.1',
         'colorlog>=4.0.2',


### PR DESCRIPTION
With the introduction of wheel, we can start using prebuilt packages for python instead of depending on local compilation.