### PR TITLE
Upgrade pyOpenSSL to 22.0.0 to fix remote secure adb

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -11,5 +11,4 @@ tinydb==3.13.0
 tqdm==4.32.1
 
 # For Secure ADB
-pyOpenSSL==19.0.0
-
+pyOpenSSL==22.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ cement==3.0.2
 clint==0.5.1
 colorlog==4.0.2
 crayons==0.2.0
-esperclient==0.0.10
+esperclient==0.0.14
 jinja2==2.10.1
 pyyaml==5.1
 requests==2.22.0

--- a/setup.py
+++ b/setup.py
@@ -37,6 +37,6 @@ setup(
         'tabulate>=0.8.3',
         'tinydb>=3.13.0',
         'tqdm>=4.32.1',
-        'pyOpenSSL==19.0.0'
+        'pyOpenSSL==22.0.0'
     ],
 )


### PR DESCRIPTION
C:\Users\Keyur Maru>espercli secureadb connect -d ESR-NNQ-AAA4Q
Traceback (most recent call last):
  File "C:\Users\Keyur Maru\AppData\Local\Programs\Python\Python310\lib\runpy.py", line 196, in _run_module_as_main
    return _run_code(code, main_globals, None,
  File "C:\Users\Keyur Maru\AppData\Local\Programs\Python\Python310\lib\runpy.py", line 86, in _run_code
    exec(code, run_globals)
  File "C:\Users\Keyur Maru\AppData\Local\Programs\Python\Python310\Scripts\espercli.exe\_main_.py", line 7, in <module>
  File "C:\Users\Keyur Maru\AppData\Local\Programs\Python\Python310\lib\site-packages\esper\main.py", line 147, in main
    app.run()
  File "C:\Users\Keyur Maru\AppData\Local\Programs\Python\Python310\lib\site-packages\cement\core\foundation.py", line 916, in run
    return_val = self.controller._dispatch()
  File "C:\Users\Keyur Maru\AppData\Local\Programs\Python\Python310\lib\site-packages\cement\ext\ext_argparse.py", line 808, in _dispatch
    return func()
  File "C:\Users\Keyur Maru\AppData\Local\Programs\Python\Python310\lib\site-packages\esper\controllers\secureadb\secureadb.py", line 122, in connect
    create_self_signed_cert(local_cert=self.app.local_cert,
  File "C:\Users\Keyur Maru\AppData\Local\Programs\Python\Python310\lib\site-packages\esper\ext\certs.py", line 150, in create_self_signed_cert
    cert.gmtime_adj_notBefore(0)
  File "C:\Users\Keyur Maru\AppData\Local\Programs\Python\Python310\lib\site-packages\OpenSSL\crypto.py", line 1349, in gmtime_adj_notBefore
    notBefore = _lib.X509_get_notBefore(self._x509)
AttributeError: module 'lib' has no attribute 'X509_get_notBefore'