### PR TITLE
Upgrade pyOpenSSL from 19.0.0 to 22.0.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -11,5 +11,5 @@ tinydb==3.13.0
 tqdm==4.32.1
 
 # For Secure ADB
-pyOpenSSL==19.0.0
+pyOpenSSL==22.0.0
 

--- a/setup.py
+++ b/setup.py
@@ -39,6 +39,6 @@ setup(
         'tabulate>=0.8.3',
         'tinydb>=3.13.0',
         'tqdm>=4.32.1',
-        'pyOpenSSL==19.0.0'
+        'pyOpenSSL==22.0.0'
     ],
 )


### PR DESCRIPTION
fixes: [SE-1054] secure remote adb