### PR TITLE
feat(DSM-2126): use remote adb url if present for secureadb connection

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,8 +6,8 @@ This package provides a unified command line interface to the Esper API Services
 Current stable release versions are
 
     API version: 1.0.0
-    SDK version: 0.0.12
-    CLI version: 0.0.12
+    SDK version: 0.1.2
+    CLI version: 0.0.13
 
 ## Requirements
 

--- a/esper/core/version.py
+++ b/esper/core/version.py
@@ -1,6 +1,6 @@
 from cement.utils.version import get_version as cement_get_version
 
-VERSION = (0, 0, 12, 'final', 0)
+VERSION = (0, 0, 13, 'final', 0)
 
 
 def get_version(version=VERSION):

--- a/esper/ext/remoteadb_api.py
+++ b/esper/ext/remoteadb_api.py
@@ -1,6 +1,7 @@
 import time
 from logging import Logger
 from typing import Tuple
+import socket
 
 import requests
 
@@ -104,6 +105,15 @@ def fetch_relay_endpoint(environment: str,
         if is_ok:
             host = remoteadb_session.get("ip")
             port = remoteadb_session.get("client_port")
+            remoteadb_host = remoteadb_session.get("remoteadb_host")
+
+            if remoteadb_host:
+                try:
+                    ip_address = socket.gethostbyname(remoteadb_host)
+                    host = ip_address
+                except socket.error as e:
+                    log.debug(f"[remoteadb-connect] Could not resolve ip address of '{remoteadb_host}', falling back to {host}. Error was: {e}")
+                    raise e
 
             if host and port:
                 port = int(port)

--- a/esper/ext/remoteadb_api.py
+++ b/esper/ext/remoteadb_api.py
@@ -113,7 +113,7 @@ def fetch_relay_endpoint(environment: str,
                     host = ip_address
                 except socket.error as e:
                     log.error(f"[remoteadb-connect] Could not resolve ip address of '{remoteadb_host}'. Error was: {e}")
-                    raise e
+                    raise Exception('Could not resolve ip address of remoteadb host. Please try again later.')
 
             if host and port:
                 port = int(port)

--- a/esper/ext/remoteadb_api.py
+++ b/esper/ext/remoteadb_api.py
@@ -112,7 +112,7 @@ def fetch_relay_endpoint(environment: str,
                     ip_address = socket.gethostbyname(remoteadb_host)
                     host = ip_address
                 except socket.error as e:
-                    log.debug(f"[remoteadb-connect] Could not resolve ip address of '{remoteadb_host}', falling back to {host}. Error was: {e}")
+                    log.error(f"[remoteadb-connect] Could not resolve ip address of '{remoteadb_host}'. Error was: {e}")
                     raise e
 
             if host and port:

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@
 from setuptools import setup, find_packages
 
 
-VERSION = "0.0.12"
+VERSION = "0.0.13"
 
 f = open('README.md', 'r', encoding='utf-8', errors='ignore')
 LONG_DESCRIPTION = f.read()


### PR DESCRIPTION
This PR adds support to TCP relay server connection using URL. 
For backward compatibility: If url doesn’t exist, connect to provided ip.