### PR TITLE
Feat: Use adb pub key for foundation devices

### DIFF
--- a/esper/ext/remoteadb_api.py
+++ b/esper/ext/remoteadb_api.py
@@ -2,7 +2,7 @@ import time
 from logging import Logger
 from typing import Tuple
 import socket
-
+from pathlib import Path
 import requests
 
 
@@ -177,6 +177,7 @@ def initiate_remoteadb_connection(environment: str,
                                   device_id: str,
                                   api_key: str,
                                   client_cert_path: str,
+                                  client_adb_pub_key_path: str,
                                   log: Logger) -> str:
     """
     Create a Remote ADB session for given enterprise and device, and return its id.
@@ -197,13 +198,25 @@ def initiate_remoteadb_connection(environment: str,
     # Convert byte stream to utf-8
     client_cert = client_cert.decode('utf-8')
 
+    adb_pub_key = ""
+    if Path(client_adb_pub_key_path).exists():
+        with open(client_adb_pub_key_path, 'rb') as f:
+            adb_pub_key = f.read()
+            # Convert byte stream to utf-8
+            adb_pub_key = adb_pub_key.decode('utf-8')
+
+    
+    adb_pub_key_exists = adb_pub_key != ""
+    log.debug(f"ADB public key exists: {adb_pub_key_exists}")
+
     log.debug("Initiating RemoteADB connection...")
     log.debug(f"Creating RemoteADB session at {url}")
 
     response = requests.post(
         url,
         json={
-            'client_certificate': client_cert
+            'client_certificate': client_cert,
+            'adb_pub_key': adb_pub_key
         },
         headers={
             'Authorization': f'Bearer {api_key}'

--- a/esper/main.py
+++ b/esper/main.py
@@ -34,6 +34,7 @@ CONFIG['esper']['certs_folder'] = '~/.esper/certs'
 CONFIG['esper']['local_key'] = '~/.esper/certs/local.key'
 CONFIG['esper']['local_cert'] = '~/.esper/certs/local.pem'
 CONFIG['esper']['device_cert'] = '~/.esper/certs/device.pem'
+CONFIG['esper']['adb_pub_key'] = '~/.android/adbkey.pub'
 
 # meta defaults
 META = init_defaults('log.colorlog')
@@ -134,6 +135,7 @@ TEST_CONFIG['esper']['certs_folder'] = '~/.esper/certs'
 TEST_CONFIG['esper']['local_key'] = '~/.esper/certs/local.key'
 TEST_CONFIG['esper']['local_cert'] = '~/.esper/certs/local.pem'
 TEST_CONFIG['esper']['device_cert'] = '~/.esper/certs/device.pem'
+TEST_CONFIG['esper']['adb_pub_key'] = '~/.android/adbkey.pub'
 
 
 class EsperTest(TestApp, Esper):


### PR DESCRIPTION
This PR enables seamless Remote ADB connection to Esper Foundation devices by pre-authorizing the client using his/her available adb public key.