### PR TITLE
fix: esper-cli app version formate changes legacy support added

### DIFF
--- a/README.md
+++ b/README.md
@@ -769,13 +769,22 @@ category
 content_rating    0.0
 compatibility
 ```
-Below example listing versions of current active app,
+Below example listing versions of current active app (default legacy format),
 ```sh
 $ espercli version list
 Total Number of Versions: 1
 
 ID                                    VERSION CODE      BUILD NUMBER    SIZE IN MB  RELEASE TRACK      INSTALLED COUNT
 54436edb-9b43-4e2c-8107-2c6fa90e2a9e  6.4.5                      189       9.36421                                   1
+```
+
+To use the new standardized format with `VERSION NAME` instead of `BUILD NUMBER`:
+```sh
+$ espercli version list --legacy-format false
+Total Number of Versions: 1
+
+ID                                    VERSION NAME    VERSION CODE    SIZE IN MB  RELEASE TRACK      INSTALLED COUNT
+54436edb-9b43-4e2c-8107-2c6fa90e2a9e  6.4.5          30204           9.36421                                   1
 ```
 
 #### 7. unset-active
@@ -809,9 +818,11 @@ $ espercli version list [OPTIONS]
 | --app, -a       |        | Application id (UUID) |
 | --code, -c      |        | Filter by version code |
 | --number, -n    |        | Filter by build number |
+| --legacy-format, -lf |true | Use legacy format, choices are [true, false] |
 | --json, -j      |        | Render result in JSON format |
 
 ##### Example
+**Default behavior (legacy format):**
 ```sh
 $ espercli version list -a 630dbfab-7d85-4f81-9f3b-ffb038b0df72
 Total Number of Versions: 1
@@ -819,6 +830,16 @@ Total Number of Versions: 1
 ID                                    VERSION CODE      BUILD NUMBER    SIZE IN MB  RELEASE TRACK      INSTALLED COUNT
 54436edb-9b43-4e2c-8107-2c6fa90e2a9e  6.4.5                      189       9.36421                                   1
 ```
+
+**New standardized format (with --legacy-format false):**
+```sh
+$ espercli version list -a 630dbfab-7d85-4f81-9f3b-ffb038b0df72 --legacy-format false
+Total Number of Versions: 1
+
+ID                                    VERSION NAME    VERSION CODE    SIZE IN MB  RELEASE TRACK      INSTALLED COUNT
+54436edb-9b43-4e2c-8107-2c6fa90e2a9e  6.4.5          30204           9.36421                                   1
+```
+
 For list of versions if active application is set,
 ```sh
 $ espercli version list
@@ -827,6 +848,8 @@ Total Number of Versions: 1
 ID                                    VERSION CODE      BUILD NUMBER    SIZE IN MB  RELEASE TRACK      INSTALLED COUNT
 54436edb-9b43-4e2c-8107-2c6fa90e2a9e  6.4.5                      189       9.36421                                   1
 ```
+
+> **Note:** By default, the CLI uses legacy format (`--legacy-format true`) which displays `BUILD NUMBER` column. Use `--legacy-format false` to get the new standardized format with `VERSION NAME` column. The new format uses `version_name` (human-readable) and `version_code` (internal identifier) instead of the legacy `build_number` and `version_code` system.
 
 #### 2. show
 Show application version information, here version id (UUID) is required to show version information.
@@ -838,9 +861,11 @@ $ espercli version show [OPTIONS] [version-id]
 | Name, shorthand | Default| Description|
 | -------------   |:------:|:----------|
 | --app, -a       |        | Application id (UUID) |
+| --legacy-format, -lf |true | Use legacy format, choices are [true, false] |
 | --json, -j      |        | Render result in JSON format |
 
 ##### Example
+**Default behavior (legacy format):**
 ```sh
 $ espercli version show -a 630dbfab-7d85-4f81-9f3b-ffb038b0df72 54436edb-9b43-4e2c-8107-2c6fa90e2a9e
 
@@ -852,6 +877,21 @@ size_in_mb       9.36421394348145
 release_track
 installed_count  1
 ```
+
+**New standardized format (with --legacy-format false):**
+```sh
+$ espercli version show -a 630dbfab-7d85-4f81-9f3b-ffb038b0df72 54436edb-9b43-4e2c-8107-2c6fa90e2a9e --legacy-format false
+
+TITLE            DETAILS
+id               54436edb-9b43-4e2c-8107-2c6fa90e2a9e
+version_name     6.4.5
+version_code     30204
+size_in_mb       9.36421394348145
+release_track
+installed_count  1
+```
+
+> **Note:** By default, the CLI uses legacy format (`--legacy-format true`) which displays `build_number`. Use `--legacy-format false` to get the new standardized format with `version_name` (human-readable version string) and `version_code` (internal unique identifier).
 
 #### 3. delete
 Delete sub command used to delete particular application version. Here, version id (UUID) is required to delete version. Application will be also deleted if application contains one version and unset active application if it is set as active

--- a/esper/controllers/application/application.py
+++ b/esper/controllers/application/application.py
@@ -219,7 +219,11 @@ class Application(Controller):
                 version = application.versions[0]
                 renderable.append({title: 'version_id', details: version.id})
                 renderable.append({title: 'version_code', details: version.version_code})
-                renderable.append({title: 'build_number', details: version.build_number})
+                # Show version_name if available (new format), otherwise fallback to build_number (legacy format)
+                if hasattr(version, 'version_name') and version.version_name:
+                    renderable.append({title: 'version_name', details: version.version_name})
+                elif hasattr(version, 'build_number') and version.build_number:
+                    renderable.append({title: 'build_number', details: version.build_number})
 
             self.app.render(renderable, format=OutputFormat.TABULATED.value, headers="keys", tablefmt="plain")
         else:
@@ -228,7 +232,11 @@ class Application(Controller):
                 version = application.versions[0]
                 renderable['version_id'] = version.id
                 renderable['version_code'] = version.version_code
-                renderable['build_number'] = version.build_number
+                # Show version_name if available (new format), otherwise fallback to build_number (legacy format)
+                if hasattr(version, 'version_name') and version.version_name:
+                    renderable['version_name'] = version.version_name
+                elif hasattr(version, 'build_number') and version.build_number:
+                    renderable['build_number'] = version.build_number
 
             self.app.render(renderable, format=OutputFormat.JSON.value)
 

--- a/esper/controllers/application/version.py
+++ b/esper/controllers/application/version.py
@@ -37,6 +37,12 @@ class ApplicationVersion(Controller):
              {'help': 'Build number',
               'action': 'store',
               'dest': 'build_number'}),
+            (['-lf', '--legacy-format'],
+             {'help': 'Use legacy format, choices are [true, false]',
+              'action': 'store',
+              'choices': ['true', 'false'],
+              'default': 'true',
+              'dest': 'legacy_format'}),
             (['-l', '--limit'],
              {'help': 'Number of results to return per page',
               'action': 'store',
@@ -75,6 +81,10 @@ class ApplicationVersion(Controller):
         build_number = self.app.pargs.build_number
         limit = self.app.pargs.limit
         offset = self.app.pargs.offset
+        
+        # Get legacy_format flag and convert to boolean
+        legacy_format_str = getattr(self.app.pargs, 'legacy_format', 'true')
+        legacy_format = (legacy_format_str == 'true')
 
         kwargs = {}
         if version_code:
@@ -86,7 +96,7 @@ class ApplicationVersion(Controller):
         try:
             # Find application versions in an enterprise
             response = application_client.get_app_versions(application_id, enterprise_id, limit=limit, offset=offset,
-                                                           **kwargs)
+                                                           legacy_format=legacy_format, **kwargs)
         except ApiException as e:
             self.app.log.error(f"[version-list] Failed to list applications: {e}")
             self.app.render(f"ERROR: {parse_error_message(self.app, e)}\n")
@@ -96,44 +106,80 @@ class ApplicationVersion(Controller):
         if not self.app.pargs.json:
             versions = []
 
-            label = {
-                'id': "ID",
-                'version_code': "VERSION CODE",
-                'build_number': "BUILD NUMBER",
-                'size_in_mb': "SIZE IN MB",
-                'release_track': "RELEASE TRACK",
-                'installed_count': "INSTALLED COUNT",
-            }
+            # Determine which columns to show based on legacy_format
+            if legacy_format:
+                # Legacy format: show BUILD NUMBER
+                label = {
+                    'id': "ID",
+                    'version_code': "VERSION CODE",
+                    'build_number': "BUILD NUMBER",
+                    'size_in_mb': "SIZE IN MB",
+                    'release_track': "RELEASE TRACK",
+                    'installed_count': "INSTALLED COUNT",
+                }
+            else:
+                # New format: show VERSION NAME
+                label = {
+                    'id': "ID",
+                    'version_name': "VERSION NAME",
+                    'version_code': "VERSION CODE",
+                    'size_in_mb': "SIZE IN MB",
+                    'release_track': "RELEASE TRACK",
+                    'installed_count': "INSTALLED COUNT",
+                }
 
             for version in response.results:
-                versions.append(
-                    {
+                if legacy_format:
+                    # Legacy format: use build_number
+                    version_dict = {
                         label['id']: version.id,
                         label['version_code']: version.version_code,
-                        label['build_number']: version.build_number,
+                        label['build_number']: version.build_number if hasattr(version, 'build_number') and version.build_number else '',
                         label['size_in_mb']: version.size_in_mb,
                         label['release_track']: version.release_track,
                         label['installed_count']: version.installed_count if version.installed_count else 0
                     }
-                )
+                else:
+                    # New format: use version_name
+                    version_dict = {
+                        label['id']: version.id,
+                        label['version_name']: version.version_name if hasattr(version, 'version_name') and version.version_name else '',
+                        label['version_code']: version.version_code,
+                        label['size_in_mb']: version.size_in_mb,
+                        label['release_track']: version.release_track,
+                        label['installed_count']: version.installed_count if version.installed_count else 0
+                    }
+                versions.append(version_dict)
             self.app.render(versions, format=OutputFormat.TABULATED.value, headers="keys", tablefmt="plain")
         else:
             versions = []
             for version in response.results:
-                versions.append(
-                    {
+                if legacy_format:
+                    # Legacy format: include build_number
+                    version_dict = {
                         'id': version.id,
                         'version_code': version.version_code,
-                        'build_number': version.build_number,
+                        'build_number': version.build_number if hasattr(version, 'build_number') and version.build_number else None,
                         'size_in_mb': version.size_in_mb,
                         'release_track': version.release_track,
                         'installed_count': version.installed_count if version.installed_count else 0
                     }
-                )
+                else:
+                    # New format: include version_name
+                    version_dict = {
+                        'id': version.id,
+                        'version_name': version.version_name if hasattr(version, 'version_name') and version.version_name else None,
+                        'version_code': version.version_code,
+                        'size_in_mb': version.size_in_mb,
+                        'release_track': version.release_track,
+                        'installed_count': version.installed_count if version.installed_count else 0
+                    }
+                versions.append(version_dict)
             self.app.render(versions, format=OutputFormat.JSON.value)
 
-    def _version_basic_response(self, version, format=OutputFormat.TABULATED):
-        valid_keys = ['id', 'version_code', 'build_number', 'size_in_mb', 'release_track']
+    def _version_basic_response(self, version, format=OutputFormat.TABULATED, legacy_format=True):
+        # Include both version_name and build_number in valid_keys for flexibility
+        valid_keys = ['id', 'version_code', 'version_name', 'build_number', 'size_in_mb', 'release_track']
 
         if format == OutputFormat.JSON:
             renderable = {k: v for k, v in version.to_dict().items() if k in valid_keys}
@@ -142,7 +188,15 @@ class ApplicationVersion(Controller):
         else:
             title = "TITLE"
             details = "DETAILS"
-            renderable = [{title: k, details: v} for k, v in version.to_dict().items() if k in valid_keys]
+            # Filter based on legacy_format
+            if legacy_format:
+                # Legacy format: prioritize build_number
+                filtered_dict = {k: v for k, v in version.to_dict().items() if k in valid_keys and k != 'version_name'}
+            else:
+                # New format: prioritize version_name
+                filtered_dict = {k: v for k, v in version.to_dict().items() if k in valid_keys and k != 'build_number'}
+            
+            renderable = [{title: k, details: v} for k, v in filtered_dict.items()]
 
             if version:
                 renderable.append(
@@ -163,6 +217,12 @@ class ApplicationVersion(Controller):
              {'help': 'Application id',
               'action': 'store',
               'dest': 'application'}),
+            (['-lf', '--legacy-format'],
+             {'help': 'Use legacy format, choices are [true, false]',
+              'action': 'store',
+              'choices': ['true', 'false'],
+              'default': 'true',
+              'dest': 'legacy_format'}),
             (['-j', '--json'],
              {'help': 'Render result in Json format',
               'action': 'store_true',
@@ -188,18 +248,22 @@ class ApplicationVersion(Controller):
 
             application_id = application.get('id')
 
+        # Get legacy_format flag and convert to boolean
+        legacy_format_str = getattr(self.app.pargs, 'legacy_format', 'true')
+        legacy_format = (legacy_format_str == 'true')
+
         try:
-            response = application_client.get_app_version(version_id, application_id, enterprise_id)
+            response = application_client.get_app_version(version_id, application_id, enterprise_id, legacy_format=legacy_format)
         except ApiException as e:
             self.app.log.error(f"[version-show] Failed to show details of an version: {e}")
             self.app.render(f"ERROR: {parse_error_message(self.app, e)}\n")
             return
 
         if not self.app.pargs.json:
-            renderable = self._version_basic_response(response)
+            renderable = self._version_basic_response(response, format=OutputFormat.TABULATED, legacy_format=legacy_format)
             self.app.render(renderable, format=OutputFormat.TABULATED.value, headers="keys", tablefmt="plain")
         else:
-            renderable = self._version_basic_response(response, OutputFormat.JSON)
+            renderable = self._version_basic_response(response, format=OutputFormat.JSON, legacy_format=legacy_format)
             self.app.render(renderable, format=OutputFormat.JSON.value)
 
     @ex(


### PR DESCRIPTION
# App Version Standardization - Summary of Changes

## Summary of Changes

### 1. API Methods Updated (`application_api.py`)

- Added `legacy_format` parameter to `get_app_version` and `get_app_version_with_http_info`
- Added `legacy_format` parameter to `get_app_versions` and `get_app_versions_with_http_info`
- Updated docstrings to document the new parameter
- Added query parameter handling for `legacy_format`

### 2. Model Updates

- **AppVersion** (`app_version.py`): Added `version_name` field with property getter/setter
- **ApplicationVersion** (`application_version.py`): Added `version_name` field with property getter/setter
- **AppInstallVersion** (`app_install_version.py`): Added `version_name` field with property getter/setter
- All models retain `build_number` for backward compatibility

### 3. Documentation Updates

- Updated `docs/AppVersion.md` - Added `version_name` property, marked `build_number` as deprecated
- Updated `docs/ApplicationVersion.md` - Added `version_name` property, marked `build_number` as deprecated
- Updated `docs/AppInstallVersion.md` - Added `version_name` property, marked `build_number` as deprecated
- Updated `docs/ApplicationApi.md` - Documented `legacy_format` parameter for both `get_app_version` and `get_app_versions`

## Key Features

- **Backward compatible**: Existing code continues to work without changes
- `legacy_format=False` returns standardized format with `version_name` and `version_code` (no `build_number`)
- `legacy_format=True` or omitted returns legacy format with `build_number`
- All changes follow existing code patterns and conventions
