### PR TITLE
feat: port CLI from Cement to Typer with full UX overhaul

### DIFF
--- a/.claude/commands/esper.md
+++ b/.claude/commands/esper.md
@@ -1,0 +1,117 @@
+---
+description: Manage your Esper device fleet — list devices, fire commands, check status, manage apps and groups. Accepts natural language requests.
+argument-hint: [what you want to do, e.g. "list inactive devices" or "reboot the warehouse group"]
+allowed-tools: Bash
+---
+
+You are an Esper fleet management assistant. You have full access to `espercli`, a CLI tool for the Esper MDM API. Use it to fulfill the user's request.
+
+**User's request:** $ARGUMENTS
+
+---
+
+## What you can do
+
+Run any `espercli` command via Bash. Always prefer short, precise commands over broad ones. Use `--json` when you need to parse output programmatically, plain output for display.
+
+### Current context
+Before doing anything else, run `espercli context` to see the active environment, enterprise, device, and group — this tells you what's already set so you don't prompt unnecessarily.
+
+---
+
+## Command reference
+
+### Devices
+```
+espercli device list [--state active|inactive|disabled] [--group NAME] [--all]
+espercli device show NAME [--active]        # --active sets it as the active device
+espercli device set-active --name NAME
+espercli device unset-active
+```
+
+### Device commands (fire at a single device)
+```
+espercli device-command ping     [--device NAME]
+espercli device-command lock     [--device NAME]
+espercli device-command reboot   [--device NAME]
+espercli device-command wipe     [--device NAME] --yes
+espercli device-command install  [--device NAME] --version VERSION_ID
+espercli device-command uninstall [--device NAME] --version VERSION_ID
+espercli device-command clear-app-data [--device NAME] --package-name PACKAGE
+espercli device-command show COMMAND_ID
+```
+
+### Groups
+```
+espercli group list [--all]
+espercli group show NAME [--active]
+espercli group create NAME
+espercli group delete NAME --yes
+espercli group devices [--group NAME]
+espercli group add    --group NAME --device DEVICE_NAME
+espercli group remove --group NAME --device DEVICE_NAME
+```
+
+### Group commands (fire at every device in a group)
+```
+espercli group-command ping    [--group NAME]
+espercli group-command lock    [--group NAME]
+espercli group-command reboot  [--group NAME]
+espercli group-command install [--group NAME] --version VERSION_ID
+espercli group-command show COMMAND_ID
+```
+
+### Applications
+```
+espercli app list [--name NAME] [--all]
+espercli app show APP_ID [--active]
+espercli app upload FILE
+espercli app delete APP_ID --yes
+espercli app set-active --id APP_ID
+espercli version list [--app APP_ID]
+espercli version show VERSION_ID [--app APP_ID]
+espercli version delete VERSION_ID --yes
+espercli version devices VERSION_ID         # which devices have this version
+espercli installs list [--device NAME]
+```
+
+### Pipelines
+```
+espercli pipeline list
+espercli pipeline show PIPELINE_ID
+espercli pipeline create --name NAME --no-of-stages N
+espercli pipeline execute start  --pipeline PIPELINE_ID
+espercli pipeline execute stop   --pipeline PIPELINE_ID
+espercli pipeline execute show   --pipeline PIPELINE_ID
+```
+
+### V2 Commands (multi-device / group batch)
+```
+espercli commandsV2 list [--command COMMAND] [--command-type device|group|dynamic]
+espercli commandsV2 command --command-type TYPE --command COMMAND --devices "name1 name2"
+espercli commandsV2 status --request REQUEST_ID
+espercli commandsV2 history --device NAME
+```
+
+### Other
+```
+espercli content list / show / upload / delete
+espercli token show / renew
+espercli enterprise show
+espercli telemetry get-data --device NAME --metric CATEGORY-METRIC --last N --period hour|day
+espercli secureadb connect --device NAME
+espercli context
+espercli about
+```
+
+---
+
+## How to respond
+
+1. **Run `espercli context` first** to understand the current state.
+2. **Translate the request into the minimal set of espercli commands** needed.
+3. **Run them**, capture the output, and present results clearly.
+4. For **destructive actions** (wipe, delete), confirm intent before running — use `--yes` only after confirming.
+5. If the request is ambiguous (e.g. "reboot my device" with no active device set), ask which device before running.
+6. If a command fails, show the error and suggest a fix.
+7. Keep responses concise — show the data, not a narration of what you did.

--- a/README.md
+++ b/README.md
@@ -1,2452 +1,350 @@
-# Esper CLI
-[![Build Status](https://travis-ci.com/esper-io/esper-cli.svg?branch=master)](https://travis-ci.com/esper-io/esper-cli) [![Gitter](https://badges.gitter.im/esper-dev/esper-cli.svg)](https://gitter.im/esper-dev/esper-cli?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge)
+# espercli
 
-This package provides a unified command line interface to the Esper API Services.
+A command-line tool for the [Esper](https://esper.io) API — manage devices, applications, groups, pipelines, and more from your terminal.
 
-Current stable release versions are
+Built with [Typer](https://typer.tiangolo.com) and [Rich](https://github.com/Textualize/rich) for a modern CLI experience: colour-coded output, tab-completion, inline help on errors, and auto-pagination.
 
-    API version: 1.0.0
-    SDK version: 0.1.3
-    CLI version: 0.0.16
+---
 
 ## Requirements
 
-1. **Python:** You must use Python 3.6 or above.
-2. **An Esper Dev Account:** You need a free Esper Dev Trial account to create an environment and generate an Esper `SERVER URL`to talk to APIs. You will choose the `ENVIRONMENT NAME` that will then be assigned as your custom URL and when you complete the sign up process your private environment will be created. See [Requesting an Esper Dev Trial account](https://docs.esper.io/home/gettingstarted.html#setup). 
-3. **Generate an API key:** API key authentication is used for accessing APIs. You will have to generate this from the Esper Dev Console once you have set up your account. For example, the Esper Dev Console for your account can be accessed at `https://foo.espercloud.com` if you choose the `ENVIRONMENT NAME` of “foo”. See [Generating an API Key](https://docs.esper.io/home/module/genapikey.html)
+- Python 3.8+
+- An Esper account with an API key ([generate one here](https://docs.esper.io/home/module/genapikey.html))
+
+---
 
 ## Installation
 
-#### Using `pip install`
+**Recommended — pipx** (isolated, no venv management needed):
 
-From PyPI
 ```sh
-pip install espercli
+pipx install git+https://github.com/avidan/esper-cli.git
 ```
 
-or
-
-From [Github](https://github.com/esper-io/esper-cli)
-```sh
-pip install git+https://github.com/esper-io/esper-cli.git
-```
-
-#### From source
-
-Download/Clone the project and install via [Setuptools](http://pypi.python.org/pypi/setuptools).
+**From source:**
 
 ```sh
-git clone https://github.com/esper-io/esper-cli.git
-
+git clone https://github.com/avidan/esper-cli.git
 cd esper-cli
-
-python setup.py install
-```
-
-> You need not install setuptools separately, they are packaged along with downloaded library
-
-
-### Usage
-
-Before using espercli, you need to tell it about your Esper credentials. For this you will need `ENVIRONMENT NAME` and `API KEY` as generated in [Requirements](#requirements) section.
-The way to get started is to run the espercli configure command:
-```sh
-$ espercli configure
-$ Environment name: foo
-$ Esper API Key: LpDriKp7MWJiRGcwc8xzREeUj8OEFa
-```
-To list available commands, either run `espercli` with no parameters or execute `espercli --help`:
-```sh
-usage: espercli [-h] [-D] [-q] [-v]
-                {group-command,group,enterprise,status,install,version,device-command,app,device,configure}
-                ...
-
-Esper CLI tool to manage resources on Esper.io API service
-
-optional arguments:
-  -h, --help            show this help message and exit
-  -D, --debug           full application debug mode
-  -q, --quiet           suppress all console output
-  -v, --version         show program's version number and exit
-
-sub-commands:
-  {secureadb,group-command,group,enterprise,status,installs,version,device-command,app,device,configure}
-    secureadb           Setup Secure ADB connection to Device
-    group-command       group-command controller
-    group               group controller
-    enterprise          enterprise controller
-    status              status controller
-    install             install controller
-    version             version controller
-    device-command      device-command controller
-    app                 app controller
-    device              device controller
-    configure           Configure the credentials for `esper.io` API Service
-    telemetry           Get telemtery data for a device over a period
-
-Usage: espercli <sub-command> [--options]
-```
-
-## *Commands*
-### **Configure**
-Configure command is used to set and modify Esper credential details and can show credential details if not given `-s` or `--set` option.
- ```sh
-$ espercli configure [OPTIONS]
-```
-
-##### Options
-| Name, shorthand| Default| Description|
-| -------------  |:------:|:----------|
-| --set, -s      |        | Set or modify credentials |
-| --json, -j     |        | Render result in JSON format |
-
-##### Example
-```sh
-$ espercli configure
-
-TITLE    DETAILS
-environment   foo
-api_key  LpDriKp7MWJiRGcwc8xzREeUj8OEFa
-```
-
-### **Token**
-Token command is used to show the information associated with the token.
-```sh
-$ espercli token [SUB-COMMANDS]
-```
-#### Sub commands
-#### 1. show
-Show token information.
-```sh
-$ espercli token show [OPTIONS]
-```
-##### Options
-| Name, shorthand| Default| Description|
-| ------------- |:-------------:|:-----|
-| --json, -j     |  | Render result in JSON format |
-     
-##### Example
-```sh
-$ espercli token show
-
-TITLE          DETAILS
-Enterprise Id  f44373cb-1800-43c6-aab3-c81f8b1f435c
-Token          U1XEFTNS1ujAMK2Q7Gl3hfPclCclhX
-Expires On     2019-11-19 15:42:16.637203+00:00
-Scope          ['read', 'write', 'update', 'introspection', 'sdk', 'register']
-Created On     2019-08-20 08:02:16.640250+00:00
-Updated On     2019-08-20 08:02:16.640275+00:00
-
-$ espercli token show -j
-{"Enterprise": "f44373cb-1800-43c6-aab3-c81f8b1f435c", "Developer App": "5b4ececb-b446-4f47-9e6f-0b47760763be", "Token": "U1XEFTNS1ujAMK2Q7Gl3hfPclCclhX", "Expires On": ["read", "write", "update", "introspection", "sdk", "register"], "Created On": "2019-08-20 08:02:16.640250+00:00", "Updated On": "2019-08-20 08:02:16.640275+00:00"}%
-```
-
-#### 2. renew
-Renew token
-```sh
-$ espercli token renew [OPTIONS]
-```
-##### Options
-| Name, shorthand     | Default | Description|
-| --------------------|:-------:|:-----------|
-| --developerapp, -d  |         | Developer App Id |       
-| --token, -t         |         | Token to renew |
-| --json, -j          |         | Render result in JSON format |
-
-##### Example
-```sh
-$ espercli token renew -d 5fa87c46-bef7-4c1f-9ca8-ebf022d118b6 -t mzbrCDAKVyHcnNye7zdYuuLVVr22Pm
-
-TITLE          DETAILS
-Id             570
-User           bindya
-Enterprise Id  f44373cb-1800-43c6-aab3-c81f8b1f435c
-Developer App  5fa87c46-bef7-4c1f-9ca8-ebf022d118b6
-Token          hP7CacqL7NJeNIWoSsRoUibHipC4el
-Scope          read write update introspection sdk register
-Created On     2020-10-06 04:29:31.638430+00:00
-Updated On     2020-10-06 04:29:31.638462+00:00
-Expires On     2023-07-03 04:29:31.631839+00:00
-
-$ espercli token renew -d 5fa87c46-bef7-4c1f-9ca8-ebf022d118b6 -t mzbrCDAKVyHcnNye7zdYuuLVVr22Pm -j
-{"Id": "571", "User": "bindya", "Enterprise Id": "f44373cb-1800-43c6-aab3-c81f8b1f435c", "Developer App": "5fa87c46-bef7-4c1f-9ca8-ebf022d118b6", "Token": "xBs7nTgIjmswBKEuYMxVNYBeLa6or5", "Scope": "read write update introspection sdk register", "Created On": "2020-10-06 04:29:53.906764+00:00", "Updated On": "2020-10-06 04:29:53.906934+00:00", "Expires On": "2023-07-03 04:29:53.906020+00:00"}%
-```
-
-### **Enterprise**
-Enterprise command used to show and modify enterprise information.
-```sh
-$ espercli enterprise [SUB-COMMANDS]
-```
-#### Sub commands
-#### 1. show
-Show enterprise information.
-```sh
-$ espercli enterprise show [OPTIONS]
-```
-##### Options
-| Name, shorthand| Default| Description|
-| ------------- |:-------------:|:-----|
-| --json, -j     |  | Render result in JSON format |
-
-##### Example
-```sh
-$ espercli enterprise show
-
-TITLE            DETAILS
-Enterprise Id    595a6107-b137-448d-b217-e20cc58ee84d
-Name             Foo Enterprise
-Registered Name  Foo Enterprise
-Address          #123, Industrial Layout, Random Avenue
-Location         Santa Clara, CA
-Zip Code         12345
-Email            contact@foo.io
-Contact Person   Shiv Sundar
-Contact Number   +145678901234
-
-$ espercli enterprise show -j
-{"Enterprise Id": "595a6107-b137-448d-b217-e20cc58ee84d", "Name": "Foo Enterprise", "Registered Name": "Foo Enterprise", "Address": "#123, Industrial Layout, Random Avenue", "Location": "Santa Clara, CA", "Zip Code": "12345", "Email": "contact@foo.io", "Contact Person": "Shiv Sundar", "Contact Number": "+145678901234"}%
-```
-
-#### 2. update
-Modify the enterprise information.
-```sh
-$ espercli enterprise update [OPTIONS]
-```
-##### Options
-| Name, shorthand | Default| Description|
-| -------------   |:------:|:----------|
-| --name, -n      |        | Enterprise name |
-| --dispname, -dn |        | Enterprise display name |
-| --regname, -rn  |        | Enterprise registered name |
-| --address, -a   |        | Enterprise address |
-| --location, -l  |        | Enterprise location |
-| --zipcode, -z   |        | Enterprise zip code |
-| --email, -e     |        | Enterprise contact email |
-| --person, -p    |        | Enterprise contact person name |
-| --number, -cn   |        | Enterprise contact number |
-| --json, -j      |        | Render result in JSON format |
-
-##### Example
-```sh
-$ espercli enterprise update -p 'Muneer M'
-
-TITLE            DETAILS
-Enterprise Id    595a6107-b137-448d-b217-e20cc58ee84d
-Name             Foo Enterprise
-Registered Name  Foo Enterprise
-Address          #123, Industrial Layout, Random Avenue
-Location         Santa Clara, CA
-Zip Code         12345
-Email            contact@foo.io
-Contact Person   Muneer M
-Contact Number   +145678901234
-```
-
-### **Device**
-Device used to list and show device information and set device as active for further commands.
-```sh
-$ espercli device [SUB-COMMANDS]
-```
-#### Sub commands
-#### 1. list
-List sub command used to list all devices and can filter results by using different options listed below. Pagination used to limit the number of results, default is 20 results per page.
-```sh
-$ espercli device list [OPTIONS]
-```
-##### Options
-| Name, shorthand | Default| Description|
-| -------------   |:------:|:----------|
-| --limit, -l     |20      | Number of results to return per page |
-| --offset, -i    |0       | The initial index from which to return the results |
-| --state, -s     |        | Filter by device state, choices are [active, inactive, disabled] |
-| --name, -n      |        | Filter by device name |
-| --group, -g     |        | Filter by group name |
-| --imei, -im     |        | Filter by device IMEI number |
-| --tags, -t      |        | Filter by a tag  |
-| --search        |        | Search by device name, alias name or device id  |
-| --serial, -se   |        | Filter by device serial number |
-| --brand, -b     |        | Filter by device brand name |
-| --gms, -gm      |        | Filter by GMS and non GMS flag, choices are [true, false] |
-| --json, -j      |        | Render result in JSON format |
-
-##### Example
-```sh
-$ espercli device list -gm false
-Number of Devices: 10
-
-ID                                    NAME          MODEL     CURRENT STATE  TAGS
-62d42cff-6979-48ed-bedf-8b25052a74d0  SNA-SNL-FZH5  QUALCOMM  INACTIVE
-9877c1f0-0435-4185-a41b-e896e33bd438  SNA-SNL-V84B  QUALCOMM  INACTIVE       kiosk, cust
-1bab8bf7-4b12-426e-a35b-00a718ec3490  SNA-SNL-XA05  POSBANK   INACTIVE       
-9cdb45ed-5bc7-433a-b08b-1c0cffffebec  SNA-SNL-N7XY  Esper     DISABLED
-d89a88f3-de5c-4acc-9eae-0868bd2fad15  SNA-SNL-U1K1  EMDOOR    INACTIVE       EM
-fc3af4e3-79f4-483f-986e-3af60bb58809  SNA-SNL-T1PX  Vertex    DISABLED       ModelV, Prod, Beta
-e2a7d069-b536-4700-b07b-4db9d9d9236c  SNA-SNL-B424  Esper     INACTIVE
-218b37c5-b1cf-4768-8340-b2bc5f701b54  SNA-SNL-BGD3  EMDOOR    INACTIVE
-647ef365-0b68-4fbd-aa11-febe54d668b1  SNA-SNL-8QJG  Intel     INACTIVE
-c7c0382e-b911-451a-9d62-54936622d3b3  SNA-SNL-R123  QUALCOMM  DISABLED
-```
-
-#### 2. show
-Show the details of the device. Here, `device-name` is required to show device information. 
-Use the `--active` or `-a` flag to mark this device as the active device. This will allow you to call further device commands without specifying the device.
-```sh
-$ espercli device show [OPTIONS] [device-name]
-```
-##### Options
-| Name, shorthand | Default| Description|
-| -------------   |:------:|:----------|
-| --active, -a    |        | Set device as active for further device specific commands |
-| --json, -j      |        | Render result in JSON format |
-
-##### Example
-```sh
-$ espercli device show -a SNA-SNL-FZH5
-
-TITLE          DETAILS
-id             62d42cff-6979-48ed-bedf-8b25052a74d0
-device_name    SNA-SNL-FZH5
-alias_name     sample
-suid           tFxCx1wRMnMIk7kO3GpkgX--VQEI_FQxC13D1Bh4yRA
-api_level      28
-template_name  NonGMS
-is_gms         False
-state          INACTIVE
-tags           kiosk, cust
-```
-
-#### 3. set-active
-The set-active sub command used to set a device as the active device and show the details of the current active device with no options.
-```sh
-$ espercli device set-active [OPTIONS]
-```
-##### Options
-| Name, shorthand | Default| Description|
-| -------------   |:------:|:----------|
-| --name, -n      |        | Device name |
-| --json, -j      |        | Render result in JSON format |
-
-##### Example
-```sh
-$ espercli device set-active -n SNA-SNL-FZH5
-
-TITLE          DETAILS
-id             62d42cff-6979-48ed-bedf-8b25052a74d0
-device_name    SNA-SNL-FZH5
-alias_name    sample
-suid           tFxCx1wRMnMIk7kO3GpkgX--VQEI_FQxC13D1Bh4yRA
-api_level      28
-template_name  NonGMS
-is_gms         False
-state          INACTIVE
-tags           kiosk, cust
-```
-
-#### 4. unset-active
-The unset-active sub command used to unset the current active device.
-```sh
-$ espercli device unset-active
-```
-
-##### Example
-```sh
-$ espercli device unset-active
-Unset the active device SNA-SNL-FZH5
-```
-
-### **Group**
-Group is used to manage a group like list, show, create and update. Also can list devices in a group, add devices to group, remove devices, move a group and set group as active for further commands.
-```sh
-$ espercli group [SUB-COMMANDS]
-```
-#### Sub commands
-#### 1. list
-List sub command is used to list all groups and can filter results by using different options listed below. Pagination is used to limit the number of results, default is 20 results per page.
-```sh
-$ espercli group list [OPTIONS]
-```
-##### Options
-| Name, shorthand | Default| Description|
-| -------------   |:------:|:----------|
-| --limit, -l     |20      | Number of results to return per page |
-| --offset, -i    |0       | The initial index from which to return the results |
-| --name, -n      |        | Filter by group name |
-| --json, -j      |        | Render result in JSON format |
-
-##### Example
-```sh
-$ espercli group list -n TestBB 
-Number of Groups: 2
-ID                                    NAME      DEVICE COUNT  PARENT ID
-bb6be630-a2fc-4b57-bafa-fdda92433684  TestBB               0  685484fa-eb6a-4ef9-a0f1-63f6febf7ce3
-5fd4e150-7a91-4d73-a379-cac0795bd949  TestBB               0  bb6be630-a2fc-4b57-bafa-fdda92433684
-```
-
-#### 2. show
-Shows the details of the group. Here, `group-name` is required and will return the information of the first group from the response list with the given name. Since nested groups allow the same name in different hierarchy levels, `group-name` and `--groupid` or `-id` option can be given together to show the corresponding group information.
-Use the `--active` or `-a` flag to mark this group as the active group. This will allow you to call further group commands without specifying the group.
-```sh
-$ espercli group show [OPTIONS] [group-name]
-```
-##### Options
-| Name, shorthand | Default| Description|
-| -------------   |:------:|:----------|
-| --groupid, -id  |        | Group id  |
-| --active, -a    |        | Set group as active for further group specific commands |
-| --json, -j      |        | Render result in JSON format |
-
-##### Example
-```sh
-$ espercli group show TestBB -a
-
-TITLE           DETAILS
-id              bb6be630-a2fc-4b57-bafa-fdda92433684
-name            TestBB
-parent_id       685484fa-eb6a-4ef9-a0f1-63f6febf7ce3
-device_count    0
-path            All devices/TestBB
-children_count  1
-
-$ espercli group show TestBB -id 5fd4e150-7a91-4d73-a379-cac0795bd949 -a
-
-TITLE           DETAILS
-id              5fd4e150-7a91-4d73-a379-cac0795bd949
-name            TestBB
-parent_id       bb6be630-a2fc-4b57-bafa-fdda92433684
-device_count    0
-path            All devices/TestBB/TestBB
-children_count  0
-```
-
-#### 3. set-active
-The set-active sub command is used to set a group as the active group and show the details of the current active group with no options. 
-Here, if `--name` or `-n` option is given, the first group from the response list with the given name will be set as the active group. If `--groupid` or `-id` option is also given, the corresponding group will be set as the active group.
-```sh
-$ espercli group set-active [OPTIONS]
-```
-##### Options
-| Name, shorthand | Default| Description|
-| -------------   |:------:|:----------|
-| --name, -n      |        | Group name |
-| --groupid, -id  |        | Group id |
-| --json, -j      |        | Render result in JSON format |
-
-##### Example
-```sh
-$ espercli group set-active -n TestBB -id 5fd4e150-7a91-4d73-a379-cac0795bd949 
-
-TITLE           DETAILS
-id              5fd4e150-7a91-4d73-a379-cac0795bd949
-name            TestBB
-parent_id       bb6be630-a2fc-4b57-bafa-fdda92433684
-device_count    0
-path            All devices/TestBB/TestBB
-children_count  0
-```
-
-#### 4. unset-active
-The unset-active sub command used to unset the current active group.
-```sh
-$ espercli group unset-active
-```
-
-##### Example
-```sh
-$ espercli group unset-active
-Unset the active group with id: bb6be630-a2fc-4b57-bafa-fdda92433684 and name: TestBB
-```
-
-#### 5. create
-Create a new group.
-```sh
-$ espercli group create [OPTIONS]
-```
-##### Options
-| Name, shorthand | Default| Description|
-| -------------   |:------:|:----------|
-| --name, -n      |        | Group name |
-| --parentid, -pid|        | Parent id  |
-| --json, -j      |        | Render result in JSON format |
-
-##### Example
-```sh
-$ espercli group create -n Test-BB -pid bb6be630-a2fc-4b57-bafa-fdda92433684
-
-TITLE           DETAILS
-id              69f5f7ac-c182-4f31-a6bc-f895bdc44a70
-name            Test-BB
-parent_id       bb6be630-a2fc-4b57-bafa-fdda92433684
-device_count    0
-path            All devices/TestBB/Test-BB
-children_count  0
-```
-
-#### 6. update
-Modify group information.
-Here, if `group-name` is given, the first group from the response list with the given name will be modified. If `--groupid` or `-id` option is also given, the corresponding group will be modified.
-```sh
-$ espercli group update [OPTIONS] [group-name]
-```
-##### Options
-| Name, shorthand | Default| Description|
-| -------------   |:------:|:----------|
-| --name, -n      |        | Group new name |
-| --groupid, -id  |        | Group id       |
-| --json, -j      |        | Render result in JSON format |
-
-##### Example
-```sh
-espercli group update TestBB -id 5fd4e150-7a91-4d73-a379-cac0795bd949 -n TestB
-
-TITLE           DETAILS
-id              5fd4e150-7a91-4d73-a379-cac0795bd949
-name            TestB
-parent_id       bb6be630-a2fc-4b57-bafa-fdda92433684
-device_count    0
-path            All devices/TestB/TestBB
-children_count  0
-```
-
-#### 7. delete
-Remove particular group. Here, if `group-name` is given, the first group from the response list with the given name will be removed. If `--groupid` or `-id` option is also given, the corresponding group will be removed.
-```sh
-$ espercli group delete [OPTIONS] [group-name] 
-```
-##### Options
-| Name, shorthand | Default| Description|
-| -------------   |:------:|:----------|
-| --groupid, -id  |        | Group id  |
-
-##### Example
-```sh
-$ espercli group delete -id 69f5f7ac-c182-4f31-a6bc-f895bdc44a70 Test-BB
-Group with name Test-BB deleted successfully
-```
-
-#### 8. add
-Add devices into a group, active group is used to add devices if `--group` or `-g` option is not given explicitly. A maximum of 1000 devices can be added at a time.
-Here, if `--group` or `-g` is given, devices will be added to the first group from the response list with the given name. If `--groupid` or `-id` is also given, then devices will be added to corresponding group.
-```sh
-$ espercli group add [OPTIONS]
-```
-##### Options
-| Name, shorthand | Default| Description|
-| -------------   |:------:|:----------|
-| --group, -g     |        | Group name |
-| --groupid, -id  |        | Group id   |
-| --devices, -d   |        | List of device names, list format is space separated |
-| --json, -j      |        | Render result in JSON format |
-
-##### Example
-```sh
-$ espercli group add -g TestBB -id bb6be630-a2fc-4b57-bafa-fdda92433684 -d DEV-ELOP-UULA
-
-TITLE           DETAILS
-id              bb6be630-a2fc-4b57-bafa-fdda92433684
-name            TestBB
-parent_id       685484fa-eb6a-4ef9-a0f1-63f6febf7ce3
-device_count    1
-path            All devices/TestBB
-children_count  1
-```
-
-#### 9. remove
-Remove devices from a group, active group is used to add devices if `--group` or `-g` option is not given explicitly. The devices will be removed from the group and will be added to its immediate parent. A maximum of 1000 devices can be removed at a time.
-Here, if `--group` or `-g` is given, devices will be removed from the first group from the response list with the given name. If `--groupid` or `-id` is also given, then devices will be removed from the corresponding group.
-```sh
-$ espercli group remove [OPTIONS]
-```
-##### Options
-| Name, shorthand | Default| Description|
-| -------------   |:------:|:----------|
-| --group, -g     |        | Group name |
-| --groupid, -id  |        | Group id   |
-| --devices, -d   |        | List of device names, list format is space separated |
-| --json, -j      |        | Render result in JSON format |
-
-##### Example
-```sh
-$ espercli group remove -g TestBB -id bb6be630-a2fc-4b57-bafa-fdda92433684 -d DEV-ELOP-UULA
-
-TITLE           DETAILS
-id              bb6be630-a2fc-4b57-bafa-fdda92433684
-name            TestBB
-parent_id       685484fa-eb6a-4ef9-a0f1-63f6febf7ce3
-device_count    0
-path            All devices/TestBB
-children_count  1
-```
-
-#### 10. devices
-List devices in a particular group, active group is used to add devices if `--group` or `-g` option is not given explicitly. Pagination used to limit the number of results, default is 20 results per page.
-Here, if `--group` or `-g` is given, devices will be listed from the first group of the response list with the given name. If `--groupid` or `-id` is also given, then devices will be listed from the corresponding group.
-```sh
-$ espercli group devices [OPTIONS] [group-name]
-```
-##### Options
-| Name, shorthand | Default| Description|
-| -------------   |:------:|:----------|
-| --limit, -l     |20      | Number of results to return per page |
-| --offset, -i    |0       | The initial index from which to return the results |
-| --group, -g     |        | Group name |
-| --groupid, -id  |        | Group id   |
-| --json, -j      |        | Render result in JSON format |
-
-##### Example
-```sh
-$ espercli group devices -id bb6be630-a2fc-4b57-bafa-fdda92433684 -g TestBB
-Number of Devices: 1
-ID                                    NAME           MODEL    CURRENT STATE    TAGS
-babc9cf5-2dbb-4382-bb9d-d6245941db35  DEV-ELOP-UULA  vivo     INACTIVE
-```
-
-#### 11. move
-Move a group. 
-Here, if `--group` or `-g` is given, the first group from the response list with the given name will be moved. If `--groupid` or `-id` is also given, then the corresponding group will be moved. If `--parent` or `-p` is given, the first group from the response list with the given name will be the parent group. If `--parentid` or `-pid` is also given, then the corresponding group will be the parent group.
-```sh
-$ espercli group move [OPTIONS]
-```
-##### Options
-| Name, shorthand | Default| Description|
-| -------------   |:------:|:----------|
-| --group, -g     |        | Group name |
-| --groupid, -id  |        | Group id   |
-| --parent, -p    |        | Parent group name |
-| --parentid, -pid|        | Parent group id   |
-| --json, -j      |        | Render result in JSON format |
-
-##### Example
-```sh
-$ espercli group move -g TestBB -id bb6be630-a2fc-4b57-bafa-fdda92433684 -pid ad3f5e01-2748-4771-bf84-e51616cdbd9b -p Test-BB
-
-TITLE           DETAILS
-id              bb6be630-a2fc-4b57-bafa-fdda92433684
-name            TestBB
-parent_id       ad3f5e01-2748-4771-bf84-e51616cdbd9b
-device_count    1
-path            All devices/Test-BB/TestBB
-children_count  1
-```
-
-### **App**
-App command used to list, show, upload and delete applications and set application as active for further commands.
-```sh
-$ espercli app [SUB-COMMANDS]
-```
-#### Sub commands
-#### 1. list
-List all applications and can filter results by using different options listed below. Pagination used to limit the number of results, default is 20 results per page.
-```sh
-$ espercli app list [OPTIONS]
-```
-##### Options
-| Name, shorthand | Default| Description|
-| -------------   |:------:|:----------|
-| --limit, -l     |20      | Number of results to return per page |
-| --offset, -i    |0       | The initial index from which to return the results |
-| --name, -n      |        | Filter by application name |
-| --package, -p   |        | Filter by package name |
-| --json, -j      |        | Render result in JSON format |
-
-##### Example
-```sh
-$ espercli app list -l 5
-Total Number of Applications: 76
-
-ID                                    NAME                PACKAGE NAME
-d7131f72-17e4-40e9-bb9e-28f1fad1f623  ATID Reader         com.atid.app.atx
-0c067884-8d72-41b5-9ed7-3e6f1f62d99d  Call Blocker        com.sappalodapps.callblocker
-630dbfab-7d85-4f81-9f3b-ffb038b0df72  Root Checker Basic  com.joeykrim.rootcheck
-4baf7157-9fee-4dc5-ab3a-81dc983d7332  Castle Clash        com.igg.castleclash
-09368a1b-a9cd-45bc-8824-7190bc0f6b7e  WiFiAnalyzer        com.vrem.wifianalyzer
-```
-
-#### 2. show
-Show the details of an application. Here, `application-id` (UUID) is required to show application information.
-Use the `--active` or `-a` flag to mark this application as the active application. This will allow you to call further app related commands without specifying the application.
-```sh
-$ espercli app show [OPTIONS] [application-id]
-```
-##### Options
-| Name, shorthand | Default| Description|
-| -------------   |:------:|:----------|
-| --active, -a    |        | Set application as active for further application specific commands |
-| --json, -j      |        | Render result in JSON format |
-
-##### Example
-```sh
-$ espercli app show -a 630dbfab-7d85-4f81-9f3b-ffb038b0df72
-
-TITLE             DETAILS
-id                630dbfab-7d85-4f81-9f3b-ffb038b0df72
-application_name  Root Checker Basic
-package_name      com.joeykrim.rootcheck
-developer
-category
-content_rating    0.0
-compatibility
-```
-
-#### 3. upload
-Upload sub command used to upload application file. Here, application file path is required to upload file.
-```sh
-$ espercli app upload [OPTIONS] [application-file]
-```
-##### Options
-| Name, shorthand | Default| Description|
-| -------------   |:------:|:----------|
-| --json, -j      |        | Render result in JSON format |
-
-##### Example
-```sh
-$ espercli app upload ~/foo/com.joeykrim.rootcheck-v1.1.apk
-Uploading......: 100%|███████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████▉| 196k/196k [00:11<00:00, 18.1kB/s, file=com.joeykrim.rootcheck-v1.1.apk]
-
-TITLE             DETAILS
-id                630dbfab-7d85-4f81-9f3b-ffb038b0df72
-application_name  Root Checker Basic
-package_name      com.joeykrim.rootcheck
-developer
-category
-content_rating    0.0
-compatibility
-version_id        e933366b-9bb2-4c41-87fe-023f839dc367
-version_code      1.0
-build_number      1
-```
-
-#### 4. download
-Download sub command used to download an application file to local system, here version id (UUID) is required to download the application version file.
-```sh
-$ espercli app download [OPTIONS] [version-id]
-```
-##### Options
-| Name, shorthand | Default| Description|
-| -------------   |:------:|:----------|
-| --app, -a       |        | Application id (UUID) |
-| --dest, -d      |        | Destination file path |
-| --json, -j      |        | Render result in JSON format |
-
-##### Example
-```sh
-$ espercli app download -a 630dbfab-7d85-4f81-9f3b-ffb038b0df72 -d ~/foo/com.joeykrim.rootcheck-v1.1.apk 54436edb-9b43-4e2c-8107-2c6fa90e2a9e
-Downloading......:  100%|███████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████▉| 196k/196k [00:11<00:00, 18.1kB/s]
-```
-
-#### 5. delete
-Delete sub command used to delete application. Here, application id (UUID) is required to delete application and unset active application if it is set as active.
-```sh
-$ espercli app delete [application-id]
-```
-
-##### Example
-```sh
-$ espercli app delete 630dbfab-7d85-4f81-9f3b-ffb038b0df72
-Application with id 630dbfab-7d85-4f81-9f3b-ffb038b0df72 deleted successfully
-```
-
-#### 6. set-active
-The set-active sub command used to set an application as active application and show active application information with no options.
-```sh
-$ espercli app set-active [OPTIONS]
-```
-##### Options
-| Name, shorthand | Default| Description|
-| -------------   |:------:|:----------|
-| --id, -i        |        | Application id |
-| --json, -j      |        | Render result in JSON format |
-
-##### Example
-```sh
-$ espercli app set-active -i 630dbfab-7d85-4f81-9f3b-ffb038b0df72
-
-TITLE             DETAILS
-id                630dbfab-7d85-4f81-9f3b-ffb038b0df72
-application_name  Root Checker Basic
-package_name      com.joeykrim.rootcheck
-developer
-category
-content_rating    0.0
-compatibility
-```
-Below example listing versions of current active app (default legacy format),
-```sh
-$ espercli version list
-Total Number of Versions: 1
-
-ID                                    VERSION CODE      BUILD NUMBER    SIZE IN MB  RELEASE TRACK      INSTALLED COUNT
-54436edb-9b43-4e2c-8107-2c6fa90e2a9e  6.4.5                      189       9.36421                                   1
-```
-
-To use the new standardized format with `VERSION NAME` instead of `BUILD NUMBER`:
-```sh
-$ espercli version list --legacy-format false
-Total Number of Versions: 1
-
-ID                                    VERSION NAME    VERSION CODE    SIZE IN MB  RELEASE TRACK      INSTALLED COUNT
-54436edb-9b43-4e2c-8107-2c6fa90e2a9e  6.4.5          30204           9.36421                                   1
-```
-
-#### 7. unset-active
-The unset-active sub command used to unset the current active application.
-```sh
-$ espercli app unset-active
-```
-
-##### Example
-```sh
-$ espercli app unset-active
-Unset the active application 630dbfab-7d85-4f81-9f3b-ffb038b0df72
-```
-
-### **Version**
-Version command used to list, show and delete application versions.
-```sh
-$ espercli version [SUB-COMMANDS]
-```
-#### Sub commands
-#### 1. list
-List all application versions and can filter results by using different options listed below. Pagination used to limit the number of results, default is 20 results per page. Active application is used to list if `--app` or `-a` option is not given explicitly.
-```sh
-$ espercli version list [OPTIONS]
-```
-##### Options
-| Name, shorthand | Default| Description|
-| -------------   |:------:|:----------|
-| --limit, -l     |20      | Number of results to return per page |
-| --offset, -i    |0       | The initial index from which to return the results |
-| --app, -a       |        | Application id (UUID) |
-| --code, -c      |        | Filter by version code |
-| --number, -n    |        | Filter by build number |
-| --legacy-format, -lf |true | Use legacy format, choices are [true, false] |
-| --json, -j      |        | Render result in JSON format |
-
-##### Example
-**Default behavior (legacy format):**
-```sh
-$ espercli version list -a 630dbfab-7d85-4f81-9f3b-ffb038b0df72
-Total Number of Versions: 1
-
-ID                                    VERSION CODE      BUILD NUMBER    SIZE IN MB  RELEASE TRACK      INSTALLED COUNT
-54436edb-9b43-4e2c-8107-2c6fa90e2a9e  6.4.5                      189       9.36421                                   1
-```
-
-**New standardized format (with --legacy-format false):**
-```sh
-$ espercli version list -a 630dbfab-7d85-4f81-9f3b-ffb038b0df72 --legacy-format false
-Total Number of Versions: 1
-
-ID                                    VERSION NAME    VERSION CODE    SIZE IN MB  RELEASE TRACK      INSTALLED COUNT
-54436edb-9b43-4e2c-8107-2c6fa90e2a9e  6.4.5          30204           9.36421                                   1
-```
-
-For list of versions if active application is set,
-```sh
-$ espercli version list
-Total Number of Versions: 1
-
-ID                                    VERSION CODE      BUILD NUMBER    SIZE IN MB  RELEASE TRACK      INSTALLED COUNT
-54436edb-9b43-4e2c-8107-2c6fa90e2a9e  6.4.5                      189       9.36421                                   1
-```
-
-> **Note:** By default, the CLI uses legacy format (`--legacy-format true`) which displays `BUILD NUMBER` column. Use `--legacy-format false` to get the new standardized format with `VERSION NAME` column. The new format uses `version_name` (human-readable) and `version_code` (internal identifier) instead of the legacy `build_number` and `version_code` system.
-
-#### 2. show
-Show application version information, here version id (UUID) is required to show version information.
-```sh
-$ espercli version show [OPTIONS] [version-id]
-```
-
-##### Options
-| Name, shorthand | Default| Description|
-| -------------   |:------:|:----------|
-| --app, -a       |        | Application id (UUID) |
-| --legacy-format, -lf |true | Use legacy format, choices are [true, false] |
-| --json, -j      |        | Render result in JSON format |
-
-##### Example
-**Default behavior (legacy format):**
-```sh
-$ espercli version show -a 630dbfab-7d85-4f81-9f3b-ffb038b0df72 54436edb-9b43-4e2c-8107-2c6fa90e2a9e
-
-TITLE            DETAILS
-id               54436edb-9b43-4e2c-8107-2c6fa90e2a9e
-version_code     6.4.5
-build_number     189
-size_in_mb       9.36421394348145
-release_track
-installed_count  1
-```
-
-**New standardized format (with --legacy-format false):**
-```sh
-$ espercli version show -a 630dbfab-7d85-4f81-9f3b-ffb038b0df72 54436edb-9b43-4e2c-8107-2c6fa90e2a9e --legacy-format false
-
-TITLE            DETAILS
-id               54436edb-9b43-4e2c-8107-2c6fa90e2a9e
-version_name     6.4.5
-version_code     30204
-size_in_mb       9.36421394348145
-release_track
-installed_count  1
-```
-
-> **Note:** By default, the CLI uses legacy format (`--legacy-format true`) which displays `build_number`. Use `--legacy-format false` to get the new standardized format with `version_name` (human-readable version string) and `version_code` (internal unique identifier).
-
-#### 3. delete
-Delete sub command used to delete particular application version. Here, version id (UUID) is required to delete version. Application will be also deleted if application contains one version and unset active application if it is set as active
-```sh
-$ espercli version delete [OPTIONS] [version-id]
-```
-
-##### Options
-| Name, shorthand | Default| Description|
-| -------------   |:------:|:----------|
-| --app, -a       |        | Application id (UUID) |
-
-##### Example
-```sh
-$ espercli version delete -a 630dbfab-7d85-4f81-9f3b-ffb038b0df72 54436edb-9b43-4e2c-8107-2c6fa90e2a9e
-Version with id 54436edb-9b43-4e2c-8107-2c6fa90e2a9e deleted successfully
-```
-
-#### 4. devices
-Returns the list of devices with the specified app version installed. Here, version id (UUID) is required to list devices. 
-```sh
-$ espercli version devices [OPTIONS] [version-id]
-```
-
-##### Options
-| Name, shorthand | Default| Description|
-| -------------   |:------:|:----------|
-| --app, -a       |        | Application id (UUID) |
-| --json, -j      |        | Render result in JSON format |
-
-##### Example
-```sh
-$ espercli version devices 'ea8ed7ae-db18-464b-81f3-e9562c40b0a8' --app 'a5f14399-c358-43f2-9e6f-06033db0d742' 
-
-Total Number of Devices: 1
-ID                                    DEVICE NAME    ALIAS NAME    GROUP NAME
-333d9856-303d-4487-91d5-be447971ead3  DEV-ELOP-FZC3                12125364365etc
+pipx install -e .
 ```
 
-### **Device-command**
-Device-command command used to fire different actions on device like lock, ping, reboot, deploy application and wipe.
-```sh
-$ espercli device-command [SUB-COMMANDS]
-```
-#### Sub commands
-#### 1. install
-Deploy an application version on device. Active device is used to install application if `--device` or `-d` option is not given explicitly.
-```sh
-$ espercli device-command install [OPTIONS]
-```
-##### Options
-| Name, shorthand | Default| Description|
-| -------------   |:------:|:----------|
-| --device, -d    |        | Device name |
-| --version, -V   |        | Application version id (UUID) |
-| --json, -j      |        | Render result in JSON format |
-
-##### Example
-```sh
-$ espercli device-command install -d SNA-SNL-3GQA -V 54436edb-9b43-4e2c-8107-2c6fa90e2a9e
-
-TITLE    DETAILS
-id       21180eef-678f-4447-87d8-e29af2bcb8e6
-command  INSTALL
-state    Command Initiated
-```
-For install command if active device is set,
-```sh
-$ espercli device-command install -V 54436edb-9b43-4e2c-8107-2c6fa90e2a9e
-
-TITLE    DETAILS
-id       21180eef-678f-4447-87d8-e29af2bcb8e6
-command  INSTALL
-state    Command Initiated
-```
+**Plain pip** (inside a virtualenv):
 
-#### 2. uninstall
-Uninstall an application version on device. Active device is used to uninstall application if `--device` or `-d` option is not given explicitly.
 ```sh
-$ espercli device-command uninstall [OPTIONS]
+pip install git+https://github.com/avidan/esper-cli.git
 ```
-##### Options
-| Name, shorthand | Default| Description|
-| -------------   |:------:|:----------|
-| --device, -d    |        | Device name |
-| --version, -V   |        | Application version id (UUID) |
-| --json, -j      |        | Render result in JSON format |
-
-##### Example
-```sh
-$ espercli device-command uninstall -d SNA-SNL-3GQA -V 54436edb-9b43-4e2c-8107-2c6fa90e2a9e
-
-TITLE    DETAILS
-id       21180eef-678f-4447-87d8-e29af2bcb8e6
-command  UNINSTALL
-state    Command Initiated
-```
 
-#### 3. ping
-Ping a device, active device is used to ping if `--device` or `-d` option is not given explicitly.
-```sh
-$ espercli device-command ping [OPTIONS]
-```
-##### Options
-| Name, shorthand | Default| Description|
-| -------------   |:------:|:----------|
-| --device, -d    |        | Device name |
-| --json, -j      |        | Render result in JSON format |
-
-##### Example
-```sh
-$ espercli device-command ping -d SNA-SNL-3GQA
-
-TITLE    DETAILS
-id       60f3f989-d59d-4c77-b4d9-aec385bd81fb
-command  UPDATE_HEARTBEAT
-state    Command Initiated
-```
+---
 
-#### 4. lock
-Lock command is used to lock screen of a device, active device is used to lock if `--device` or `-d` option is not given explicitly.
-```sh
-$ espercli device-command lock [OPTIONS]
-```
-##### Options
-| Name, shorthand | Default| Description|
-| -------------   |:------:|:----------|
-| --device, -d    |        | Device name |
-| --json, -j      |        | Render result in JSON format |
-
-##### Example
-```sh
-$ espercli device-command lock -d SNA-SNL-3GQA
-
-TITLE    DETAILS
-id       6e00220d-9bc2-4176-839a-fb690f72f6e2
-command  LOCK
-state    Command Initiated
-```
+## Quick start
 
-#### 5. reboot
-Reboot command is used to reboot a device, active device is used to lock if `--device` or `-d` option is not given explicitly.
-```sh
-$ espercli device-command reboot [OPTIONS]
-```
-##### Options
-| Name, shorthand | Default| Description|
-| -------------   |:------:|:----------|
-| --device, -d    |        | Device name |
-| --json, -j      |        | Render result in JSON format |
-
-##### Example
 ```sh
-$ espercli device-command reboot -d SNA-SNL-3GQA
-
-TITLE    DETAILS
-id       6e00220d-9bc2-4176-839a-fb690f72f165
-command  REBOOT
-state    Command Initiated
-```
+# 1. Configure credentials (run once)
+espercli configure
 
-#### 6. wipe
-Wipe a device, active device is used to wipe if `--device` or `-d` option is not given explicitly.
-```sh
-$ espercli device-command wipe [OPTIONS]
-```
-##### Options
-| Name, shorthand | Default| Description|
-| -------------   |:------:|:----------|
-| --device, -d    |        | Device name |
-| --exstorage, -e |        | External storage needed to wipe or not |
-| --frp, -f       |        | Factory reset production enabled or not |
-| --json, -j      |        | Render result in JSON format |
-
-##### Example
-```sh
-$ espercli device-command wipe -d SNA-SNL-3GQA -e -f
-
-TITLE    DETAILS
-id       8000220d-9bc2-4176-839a-fb690f72f165
-command  WIPE
-state    Command Initiated
-```
+# 2. Check your active context at any time
+espercli context
 
-#### 7. Clear app data
-Clear app data, active device is used to clear app data if `--device` or `-d` option is not given explicitly.
-```sh
-$ espercli device-command clear-app-data [OPTIONS]
-```
-##### Options
-| Name, shorthand | Default| Description|
-| -------------   |:------:|:----------|
-| --device, -d    |        | Device name |
-| --package-name, -P |        | Package name of app to clear data from |
-| --json, -j      |        | Render result in JSON format |
-
-##### Example
-```sh
-$ espercli device-command clear-app-data -d SNA-SNL-3GQA -P com.google.android.gms.maps
-
-TITLE    DETAILS
-id       8000220d-9bc2-4176-839a-fb690f72f165
-command  CLEAR_APP_DATA
-state    Command Initiated
-```
+# 3. List your devices
+espercli device list
 
-#### 8. show
-Show device-command information and command id (UUID) is required to show command information. This is used active device to show command if `--device` or `-d` option is not given explicitly.
-```sh
-$ espercli device-command show [OPTIONS] [command-id]
-```
-##### Options
-| Name, shorthand | Default| Description|
-| -------------   |:------:|:----------|
-| --device, -d    |        | Device name |
-| --json, -j      |        | Render result in JSON format |
-
-##### Example
-```sh
-$ espercli device-command show 6e00220d-9bc2-4176-839a-fb690f72f6e2 -d SNA-SNL-3GQA
-
-TITLE    DETAILS
-id       60f3f989-d59d-4c77-b4d9-aec385bd81fb
-command  UPDATE_HEARTBEAT
-state    Command Success
-```
+# 4. Set a device as active for subsequent commands
+espercli device show <name> --active
 
-### **Group-command**
-Group-command command used to fire different actions on group like lock, ping, reboot and deploy application.
-```sh
-$ espercli group-command [SUB-COMMANDS]
+# 5. Explore any command with --help
+espercli device --help
+espercli device list --help
 ```
-#### Sub commands
-#### 1. install
-Deploy an application version on a group. Active group is used to install application if `--group` or `-g` option is not given explicitly.
-```sh
-$ espercli group-command install [OPTIONS]
-```
-##### Options
-| Name, shorthand | Default| Description|
-| -------------   |:------:|:----------|
-| --group, -g     |        | Group name |
-| --version, -V   |        | Application version id (UUID) |
-| --json, -j      |        | Render result in JSON format |
-
-##### Example
-```sh
-$ espercli group-command install -g 5G -V 54436edb-9b43-4e2c-8107-2c6fa90e2a9e
-
-TITLE        DETAILS
-id           6cda46b4-05da-4e76-b7ae-4af52ce288fa
-command      INSTALL
-state        Command Initiated
-success
-failed
-in_progress
-inactive
-```
-For list of versions if active group is set,
-```sh
-$ espercli group-command install -V 54436edb-9b43-4e2c-8107-2c6fa90e2a9e
-
-TITLE        DETAILS
-id           6cda46b4-05da-4e76-b7ae-4af52ce288fa
-command      INSTALL
-state        Command Initiated
-success
-failed
-in_progress
-inactive
-```
 
-#### 2. ping
-Ping a group, active group is used to ping if `--group` or `-g` option is not given explicitly.
-```sh
-$ espercli group-command ping [OPTIONS]
-```
-##### Options
-| Name, shorthand | Default| Description|
-| -------------   |:------:|:----------|
-| --group, -g     |        | Group name |
-| --json, -j      |        | Render result in JSON format |
-
-##### Example
-```sh
-$ espercli group-command ping -g 5G
-
-TITLE        DETAILS
-id           077b202f-d515-45bd-9764-8f9b42416959
-command      UPDATE_HEARTBEAT
-state        Command Initiated
-success
-failed
-in_progress
-inactive
-```
+---
 
-#### 3. lock
-Lock command is used to lock screen of a group of devices, active group is used to lock if `--group` or `-g` option is not given explicitly.
-```sh
-$ espercli group-command lock [OPTIONS]
-```
-##### Options
-| Name, shorthand | Default| Description|
-| -------------   |:------:|:----------|
-| --group, -g     |        | Group name |
-| --json, -j      |        | Render result in JSON format |
-
-##### Example
-```sh
-$ espercli group-command lock -g 5G
-
-TITLE        DETAILS
-id           4752969d-b51f-410f-8b3b-956db59f8a61
-command      LOCK
-state        Command Initiated
-success
-failed
-in_progress
-inactive
-```
+## Tab completion
 
-#### 4. reboot
-Reboot command is used to reboot group of devices, active group is used to lock if `--group` or `-g` option is not given explicitly.
-```sh
-$ espercli group-command reboot [OPTIONS]
-```
-##### Options
-| Name, shorthand | Default| Description|
-| -------------   |:------:|:----------|
-| --group, -g     |        | Group name |
-| --json, -j      |        | Render result in JSON format |
-
-##### Example
-```sh
-$ espercli group-command reboot -g 5G
-
-TITLE        DETAILS
-id           b55d18ab-ff92-405b-8598-373594dd394e
-command      REBOOT
-state        Command Initiated
-success
-failed
-in_progress
-inactive
-```
+Install once and restart your terminal:
 
-#### 5. show
-Show group-command information and command id (UUID) is required to show command information. This is used active group to show command if `--group` or `-g` option is not given explicitly.
-```sh
-$ espercli group-command show [OPTIONS] [command-id]
-```
-##### Options
-| Name, shorthand | Default| Description|
-| -------------   |:------:|:----------|
-| --group, -g     |        | Group name |
-| --json, -j      |        | Render result in JSON format |
-
-##### Example
-```sh
-$ espercli group-command show -g 5G b55d18ab-ff92-405b-8598-373594dd394e
-
-TITLE        DETAILS
-id           b55d18ab-ff92-405b-8598-373594dd394e
-command      REBOOT
-state        Command Success
-success      SNA-SNL-73YE
-             SNA-SNL-NYWL
-failed
-in_progress
-inactive     
-```
- 
-### **Installs**
-Installs command used to list all installations on a device.
 ```sh
-$ espercli installs [SUB-COMMANDS]
+espercli completion zsh        # zsh
+espercli completion bash       # bash
+espercli completion fish       # fish
+espercli completion powershell # PowerShell
 ```
-#### Sub commands
-#### 1. list
-List all application installations on a device and can filter results by using different options listed below. Pagination used to limit the number of results, default is 20 results per page. Active device is used to list if `--device` or `-d` option is not given explicitly.
-```sh
-$ espercli installs list [OPTIONS]
-```
-##### Options
-| Name, shorthand | Default| Description|
-| -------------   |:------:|:----------|
-| --limit, -l     |20      | Number of results to return per page |
-| --offset, -i    |0       | The initial index from which to return the results |
-| --device, -d    |        | Device name |
-| --appname, -an  |        | Application name |
-| --package, -p   |        | Application package name |
-| --state, -s     |        | Install state. Values are [Installation In-Progress, Uninstallation In-Progress, Install Success, Install Failed, Uninstall Success, Uninstall Failed] |
-| --json, -j      |        | Render result in JSON format |
-
-##### Example
- ```sh
-$ espercli installs list -d SNA-SNL-3GQA
-Total Number of Installs: 1
-
-ID                                    APPLICATION         PACKAGE                 VERSION            STATE
-fc9e0d4e-fc88-4729-a575-7d4645901f1d  Root Checker Basic  com.joeykrim.rootcheck  6.4.5              Install Success
- ```
- 
-### **status**
-Status command used to list latest device event information.
-```sh
-$ espercli status [SUB-COMMANDS]
-```
-#### Sub commands
-#### 1. latest
-Show latest device event, active device is used to list if `--device` or `-d` option is not given explicitly.
-```sh
-$ espercli status latest [OPTIONS]
-```
-##### Options
-| Name, shorthand | Default| Description|
-| -------------   |:------:|:----------|
-| --device, -d    |        | Device name |
-| --json, -j      |        | Render result in JSON format |
-
-##### Example
- ```sh
- $ espercli status latest -d SNA-SNL-3GQA
-
-TITLE                  DETAILS
-battery_level               98
-battery_temperature         25
-data_download           366914
-data_upload             130956
-memory_storage            8294
-memory_ram                1177
-link_speed                  65
-signal_strength              2
- ```
-
-### **secureadb**
-Secureadb is a new feature that allows users to connect to their devices over Remote adb (using `adb-tools`), over the 
-internet, securely.
-```sh
-$ espercli secureadb [SUB-COMMANDS]
-```
-#### Sub commands
-#### 1. connect
-Establish a secure connection to the device; active device is used to connect if `--device` or `-d` option is not given explicitly.
-
-This will open a local endpoint on your machine, to which the `adb-tool` can connect.
-This local service will relay the traffic, securing by TLS encryption, from adb-tools to the device.
-This will also keep running until `adb disconnect` is run, or the application is quit by `Ctrl+C`. 
-```sh
-$ espercli secureadb connect [OPTIONS]
-```
-##### Options
-| Name, shorthand | Default| Description|
-| -------------   |:------:|:----------|
-| --device, -d    |        | Device name |
 
-##### Example
- ```sh
- $ espercli secureadb connect -d SNA-SNL-3GQA
+After installing, pressing `<Tab>` completes:
 
-Initiating Remote ADB Session. This may take a few seconds...
+- **Sub-commands** — `espercli dev<TAB>` → `device`
+- **Enum values** — `espercli device list --state <TAB>` → `active`, `inactive`, `disabled`, …
+- **Device names** — `espercli device show <TAB>` → live names from your enterprise
+- **Group names** — `espercli group-command reboot --group <TAB>`
+- **Application IDs** — `espercli version list --app <TAB>` (shows app name as hint)
+- **Command names, schedule types, days, and more**
 
-Secure ADB Client
-Please connect ADB client to the following endpoint: 127.0.0.1 : 62945
-If adb-tools is installed, please run the command below:
-        adb connect 127.0.0.1:62945
+---
 
-Press Ctrl+C to quit!
+## Commands
 
- ```
+### `configure`
+Set credentials (environment name and API key). Run this first.
 
-### **telemetry**
-This is used to view telemetry data for a device over a period
-```sh
-$ espercli telemetry [SUB-COMMANDS]
-```
-#### Sub commands
-#### 1. get-data
-It fetches the telemetry data for a specific device, for a specific metric aggregated by 
-`hour` or `month` or `day` and is specified by `-p, --period flag`. The statistic function is specified by may be `avg`, `sum` or `count` 
-and is specified by `-s, --statistic` flag. Metric format is `{category}-{metric_name}`. 
-The timespan to fetch telemetry data can be specified using two ways: Using `-l, --last` option or
-`-t, --to` and `-f, --from` combination. 
-
-To use `-l, --last` option use a number to specify number of hours, days, months relative to now for which data is required.
-To specify absolute date range use `-f, --from` and `-t, --to` combination.
-
-Available metric names {category}-{metric_name}
-    
-    battery-level
-    battery-temperature
-    battery-voltage
-    battery-capacity_count
-    battery-current_avg
-    battery-current
-    battery-energy_count
-    battery-low_indicator
-    battery-present
-    battery-level_absolute
-    battery-scale
-    battery-charge_time_remaining
-    memory-available_ram_measured
-    memory-available_internal_storage_measured
-    memory-os_occupied_storage_measured
-    wifi_network-signal_strength
-    wifi_network-link_speed
-    wifi_network-frequency	
-    data_usage-total_data_download
-    data_usage-total_data_upload`
-          
 ```sh
-$ espercli telemetry get-data [OPTIONS]
+espercli configure
 ```
-##### Options
-| Name, shorthand | Default| Description|
-| -------------   |:------:|:----------|
-| --device, -d    |        | Device name |
-| --metric, -m    |        | Metric in format {category}-{metric_name} |
-| --from, -f      |   {2 days since now}     | Start date time of telemetry data |
-| --period, -p    |   hour | Aggregation period |
-| --statistic, -s |   avg  | Statistic function |
-| --last, -l      |        | Relative time from now. Use -n for n hour\'s since or n days since |
-| --to, -t        |  {now} | End date time of telemetry data |
-
-##### Example
- ```sh
- $ espercli telemetry get-data -m battery-level -l 7 -p month -d DEV-ELOP-FXVW
-
-Telemetry data for device DEV-ELOP-FXVD
-Time                    Value
-2019-12-01T00:00:00Z  69.2948
-
-$ espercli telemetry get-data -d DEV-ELOP-FXVD -m battery-level -f 2019-12-15T12:36:36 -t 2019-12-17T12:36:36
-Telemetry data for device DEV-ELOP-FXVD
-Time                    Value
-2019-12-16T04:00:00Z
-2019-12-16T05:00:00Z  26.5333
-2019-12-16T06:00:00Z  41.3333
-2019-12-16T07:00:00Z  48.25
-2019-12-16T08:00:00Z  52
-2019-12-16T09:00:00Z  60
-2019-12-16T11:00:00Z  65
-2019-12-17T06:00:00Z  85.125
-2019-12-17T07:00:00Z  82.4
-```
 
+---
 
-## **Pipeline**
-Pipelines is used to create workflows consisting of actions to such as APP-INSTALL/APP-UNINSTALL/etc.
+### `device`
 ```sh
-$ espercli pipeline
-
-usage: espercli pipeline [-h] {execute,stage,create,edit,remove,show} ...
-
-Pipeline commands
-
-optional arguments:
-  -h, --help            show this help message and exit
-
-sub-commands:
-  {execute,stage,create,edit,remove,show}
-    execute             execute controller
-    stage               stage controller
-    create              Create a pipeline
-    edit                Edit a pipeline(s)
-    remove              Remove a Pipeline
-    show                List or Fetch a pipeline(s)
+espercli device list                          # list all devices (paginated)
+espercli device list --state active           # filter by state
+espercli device list --group "Warehouse"      # filter by group
+espercli device list --all                    # fetch every device (auto-paginate)
 
-Usage: espercli pipeline
-```
-#### Sub commands
-#### 1. create
-Create a new Pipeline
-
-
-```sh
-$ espercli pipeline create [OPTIONS]
-```
-##### Options
-| Name, shorthand | Default| Description      |
-|:---------------:|:------:|:----------------:|
-| --name, -n      | [opt] | Name of Pipeline |
-| --desc          | [opt] | Description for Pipeline |
-
-##### Example
- ```sh
- $ espercli pipeline create 
-
-Name of the Pipeline: <Pipeline Name>
-Description for this Pipeline [optional]: <BLah>
-What type of trigger do you want for your Pipeline?
-[1] NewAppVersionEvent
-[2] Skip for now...
-
-1
-Enter the Application name: <Blah>
-Enter the Package name: <com.blah>
-
- ```
-
-#### 2. edit
-Edit an existing Pipeline
+espercli device show <name>                   # show device details
+espercli device show <name> --active          # show + set as active device
 
-```sh
-$ espercli pipeline edit [OPTIONS]
+espercli device set-active --name <name>      # set active device
+espercli device unset-active                  # clear active device
 ```
-##### Options
-| Name, shorthand   | Default | Description |
-|:-----------------:|:-------:|:-----------:|
-| --name, -n        | [opt]   | Name of Pipeline |
-| --desc            | [opt]   | Description for Pipeline |
-| --pipeline-id, -p | [opt]   | Pipeline ID |
 
-##### Example
- ```sh
- $ espercli pipeline edit 
+---
 
-Change the name of the Pipeline: <blah>
-Change the description for this Pipeline [optional]: <blah>
-Enter the Pipeline ID:
-What type of trigger do you want for your Pipeline?
-[1] NewAppVersionEvent
-[2] Skip for now...
+### `device-command`
+Fire commands at a single device (uses the active device if `--device` is omitted).
 
-
- ```
-
-#### 3. remove
-Remove an existing Pipeline
-
 ```sh
-$ espercli pipeline remove [OPTIONS]
+espercli device-command ping
+espercli device-command lock    --device <name>
+espercli device-command reboot  --device <name>
+espercli device-command wipe    --device <name>          # requires confirmation
+espercli device-command install --device <name> --version <version-id>
+espercli device-command uninstall --device <name> --version <version-id>
+espercli device-command clear-app-data --device <name> --package-name com.example.app
+espercli device-command show <command-id>
 ```
-##### Options
-| Name, shorthand   | Default | Description |
-|:-----------------:|:-------:|:-----------:|
-| --pipeline-id, -p | [opt]   | Pipeline ID |
-
-##### Example
- ```sh
- $ espercli pipeline remove 
-
-Enter the Pipeline ID: ...
 
- ```
+---
 
-#### 4. show
-List one or all Pipelines
-
+### `group`
 ```sh
-$ espercli pipeline show [OPTIONS]
+espercli group list
+espercli group list --all                     # auto-paginate
+espercli group show <name>
+espercli group show <name> --active           # set as active group
+espercli group create <name>
+espercli group update <name> --name <new-name>
+espercli group delete <name>                  # requires confirmation
+espercli group devices                        # list devices in active group
+espercli group add --group <name> --device <device-name>
+espercli group remove --group <name> --device <device-name>
+espercli group move --group <name> --parent <parent-name>
 ```
-##### Options
-| Name, shorthand   | Default | Description |
-|:-----------------:|:-------:|:-----------:|
-| --pipeline-id, -p | [opt]   | Pipeline ID |
-
-##### Example
- ```sh
- $ espercli pipeline show 
-
-ID                                    NAME              DESCRIPTION    STAGES    VERSION  TRIGGER              TRIGGER-APP
-db26ae3b-dd80-4b91-8a21-e6e7bf3099af  Jeryn CLI                           1          4     NewAppVersionEvent    Firefox
-9c36afa8-b710-4c28-b72f-8555a69fd907  asdcafsd           asdasfd          0          1     NewAppVersionEvent    Candy Crush Saga
-3c7fbc8a-c420-4e14-8036-a6ff4a7efb58  asd                asdas            1          1     NewAppVersionEvent    Candlei
- ```
-
-## Pipeline Stages
-These sub command are used to add various named Stages to the Pipeline. 
-A Stage is a logical grouping for the various operations. Each stage has a `ordering` field
-that tells in what order the stages have to processed by the pipeline. The pipeline orders the 
-stages in ascending order of `ordering` value, and process accordingly.
-
-Please note this command depends on an existing pipeline. A Pipeline needs to be created first, before 
-the stage sub-commands can be run.
-
-
-```sh
-$ espercli pipeline stage
-
-usage: espercli pipeline stage [-h] {operation,create,edit,remove,show} ...
-
-Pipeline Stage commands
 
-optional arguments:
-  -h, --help            show this help message and exit
+---
 
-sub-commands:
-  {operation,create,edit,remove,show}
-    operation           operation controller
-    create              Add a Stage
-    edit                Edit a Stage
-    remove              Remove a Stage
-    show                List all Stages
+### `group-command`
+Fire commands at every device in a group.
 
-Usage: espercli pipeline stage
-```
-
-#### Sub commands
-#### 1. create
-Add a new stage to an existing pipeline
-
 ```sh
-$ espercli pipeline stage create [OPTIONS]
+espercli group-command ping    --group <name>
+espercli group-command lock    --group <name>
+espercli group-command reboot  --group <name>
+espercli group-command install --group <name> --version <version-id>
+espercli group-command show <command-id>
 ```
-##### Options
-| Name, shorthand   | Default | Description |
-|:-----------------:|:-------:|:-----------:|
-| --pipeline-id, -p | [opt]   | Pipeline ID |
-| --name, -n        | [opt]   | Name of Stage |
-| --desc            | [opt]   | Description for Stage |
-| --ordering        | [opt]   | Ordering for stage |
-
-##### Example
- ```sh
- $ espercli pipeline stage create 
-
-Enter the Pipeline ID: <uuid of pipeline>
-Name of the Stage: <name of stage>
-Order of this Stage: 10
-Description for this Stage [optional]:
-Added Stage to Pipeline Successfully! Details:
-
-TITLE        DETAILS
-id           86cd9c84-59be-4c89-a609-d76f85e38d53
-operations   []
-client       f44373cb-1800-43c6-aab3-c81f8b1f435c
-name         blah
-description
-created_on   2019-12-26T05:23:09.185749Z
-updated_on   2019-12-26T05:23:09.185795Z
-version      1
-ordering     10
-pipeline     904bf55d-f39f-4dc7-b085-014712c567fc
- ```
- 
- #### 2. edit
-Edit an existing stage
 
-```sh
-$ espercli pipeline stage edit [OPTIONS]
-```
-##### Options
-| Name, shorthand   | Default | Description |
-|:-----------------:|:-------:|:-----------:|
-| --pipeline-id, -p | [opt]   | Pipeline ID |
-| --stage-id, -s    | [opt]   | Stage ID |
-| --name, -n        | [opt]   | Name of Stage |
-| --desc            | [opt]   | Description for Stage |
-| --ordering        | [opt]   | Ordering for stage |
-
-##### Example
- ```sh
- $ espercli pipeline stage edit 
-
-Enter the Pipeline ID: <uuid of pipeline>
-Enter the Stage ID: <uuid>
-Change the name of the Stage:
-Change the description for this Stage [optional]:
-Change the Ordering for this Stage [optional]:
-
-TITLE        DETAILS
-id           <uuid>
-operations   []
-client       <uuid>
-name         blah
-description
-created_on   2019-12-26T05:23:09.185749Z
-updated_on   2019-12-26T05:23:09.185795Z
-version      1
-ordering     10
-pipeline     <uuid>
-
- ```
-
-#### 3. remove
-Remove an existing Stage
+---
 
+### `app`
 ```sh
-$ espercli pipeline stage remove [OPTIONS]
+espercli app list
+espercli app list --name "MyApp"
+espercli app list --all                       # auto-paginate
+espercli app show <app-id>
+espercli app show <app-id> --active           # set as active application
+espercli app upload <path/to/app.apk>
+espercli app download <version-id> --dest ./app.apk
+espercli app delete <app-id>                  # requires confirmation
+espercli app set-active --id <app-id>
+espercli app unset-active
 ```
-##### Options
-| Name, shorthand   | Default | Description |
-|:-----------------:|:-------:|:-----------:|
-| --pipeline-id, -p | [opt]   | Pipeline ID |
-| --stage-id, -s    | [opt]   | Stage ID |
 
-
-##### Example
- ```sh
- $ espercli pipeline remove 
-
-Enter the Pipeline ID: <uuid of pipeline>
-Enter the Stage ID: <uuid>
-
- ```
-
-#### 4. show
-List one or all stages in a pipeline
-
-```sh
-$ espercli pipeline stage show [OPTIONS]
-```
-##### Options
-| Name, shorthand   | Default | Description |
-|:-----------------:|:-------:|:-----------:|
-| --pipeline-id, -p | [opt]   | Pipeline ID |
-| --stage-id, -s    | [opt]   | Stage ID    |
-
-##### Example
- ```sh
- $ espercli pipeline stage show 
-
-ID            NAME      DESCRIPTION   ORDERING    OPERATIONS  VERSION
-<stage uuid>  2           2           2             0          1
-<stage uuid>  3           3           3             0          1
-<stage uuid>  blah                    10            0          1
-
- ```
- 
-## Pipeline Operations
-These sub command are used to add various named Operations to the Stage of a Pipeline. 
-An Operation defines an `Action` - such as `APP_INSTALL`, `APP_UNINSTALL`, ETC. Each operation has a `ordering` field, 
-just like stages. The pipeline orders the operations in ascending order of `ordering` value, within a given stage, 
-and processes them accordingly.
-
-Note:
-    If a `NewAppUploadEvent` trigger has been defined for the pipeline, then `APP_INSTALL`/`APP_UNINSTALL` operations, 
-    will install/uninstall the app from the `NewAppUploadEvent`.
-
-Please note this command depends on an existing Stage. A Stage needs to be created first, before the operations
-sub-commands can be run.
+---
 
+### `version`
+Manage versions of the active (or specified) application.
 
 ```sh
-$ espercli pipeline stage operation
-
-usage: espercli pipeline stage operation [-h] {create,edit,remove,show} ...
-
-Pipeline Stage Operation commands
-
-optional arguments:
-  -h, --help            show this help message and exit
-
-sub-commands:
-  {create,edit,remove,show}
-    create              Add a Operation
-    edit                Edit an Operation
-    remove              Remove an Operation
-    show                List all Operations
-
-Usage: espercli pipeline stage operation
+espercli version list
+espercli version list --app <app-id>
+espercli version list --legacy-format false   # show version_name instead of build_number
+espercli version show <version-id>
+espercli version delete <version-id>          # requires confirmation
+espercli version devices <version-id>         # list devices with this version installed
 ```
 
-#### Sub commands
-#### 1. create
-Add a new Operation to an existing Stage
+---
 
+### `installs`
 ```sh
-$ espercli pipeline stage operation create [OPTIONS]
+espercli installs list                        # installs for active device
+espercli installs list --device <name>
+espercli installs show <install-id>
 ```
-##### Options
-| Name, shorthand   | Default | Description |
-|:-----------------:|:-------:|:-----------:|
-| --pipeline-id, -p | [opt]   | Pipeline ID |
-| --stage-id, -s    | [opt]   | Stage ID |
-| --name, -n        | [opt]   | Name of Operation |
-| --desc            | [opt]   | Description for Operation |
-| --action, -a       | [opt]   | Action for Operation |
-| --ordering        | [opt]   | Ordering for Operation |
-
-##### Example
- ```sh
- $ espercli pipeline stage operation create 
-
-Enter the Pipeline ID: <uuid of pipeline>
-Enter the Stage ID: <uuid of stage>
-Name of the Operation: <name of operation>
-Action for this Operation:
-
-1: App Install to a Group of Devices
-2: App Uninstall to a Group of Devices
-3: Reboot a Group of Devices
-
-Enter the number for your selection: 1
-Name of the Group (to which the command must be fired): <group-name>
-Description for this Operation [optional]: 
-Added Operation to Stage Successfully! Details:
-
-TITLE        DETAILS
-id           <operation uuid>
-action       APP_INSTALL
-action_args  {'url': '<group-command url>', 'body': {'command': 'INSTALL'}, 'method': 'POST', 'headers': {'Authorization': 'Bearer <oauth creds>'}}
-client       f44373cb-1800-43c6-aab3-c81f8b1f435c
-name         <name of operation>
-description  
-created_on   2019-12-26T06:19:50.329913Z
-updated_on   2019-12-26T06:19:50.329944Z
-version      1
-ordering     1
-pipeline     <pipeline uuid>
-stage        <stage uuid>
- ```
- 
- #### 2. edit
-Edit an existing operation
 
-```sh
-$ espercli pipeline stage operation edit [OPTIONS]
-```
-##### Options
-| Name, shorthand   | Default | Description |
-|:-----------------:|:-------:|:-----------:|
-| --pipeline-id, -p | [opt]   | Pipeline ID |
-| --stage-id, -s    | [opt]   | Stage ID |
-| --operation-id, -o| [opt]   | Operation ID |
-| --name, -n        | [opt]   | Name of Operation |
-| --desc            | [opt]   | Description for Operation |
-| --action, -a       | [opt]   | Action for Operation |
-| --ordering        | [opt]   | Ordering for Operation |
-
-##### Example
- ```sh
- $ espercli pipeline stage operation edit 
-
-Enter the Pipeline ID: <uuid of pipeline>
-Enter the Stage ID: <uuid of stage>
-Enter the Operation ID: <uuid>
-Change the name of the Operation:
-Change the description for this Operation [optional]:
-Action for this Operation:
-
-1: App Install to a Group of Devices
-2: App Uninstall to a Group of Devices
-3: Reboot a Group of Devices
-
-Enter the number for your selection: 1
-Edited Operation for this Stage Successfully! Details:
-
-TITLE        DETAILS
-id           <operation uuid>
-action       APP_INSTALL
-action_args  {'url': '<group-command url>', 'body': {'command': 'INSTALL'}, 'method': 'POST', 'headers': {'Authorization': 'Bearer <oauth creds>'}}
-client       <uuid>
-name         Jeryn
-description  blah
-created_on   2019-12-26T06:19:50.329913Z
-updated_on   2019-12-26T07:00:54.485012Z
-version      2
-ordering     1
-pipeline     <pipeline uuid>
-stage        <stage uuid>
- ```
-
-#### 3. remove
-Remove an existing Stage
+---
 
+### `status`
 ```sh
-$ espercli pipeline stage remove [OPTIONS]
+espercli status show                          # status for active device
+espercli status show --device <name>
+espercli status list
 ```
-##### Options
-| Name, shorthand   | Default | Description |
-|:-----------------:|:-------:|:-----------:|
-| --pipeline-id, -p | [opt]   | Pipeline ID |
-| --stage-id, -s    | [opt]   | Stage ID |
-| --operation-id, -o| [opt]   | Operation ID |
-
-
-##### Example
- ```sh
- $ espercli pipeline stage operation remove 
-
-Enter the Pipeline ID: <uuid of pipeline>
-Enter the Stage ID: <uuid of stage>
-Enter the Operation ID: <uuid>
-
- ```
 
-#### 4. show
-List one or all stages in a pipeline
+---
 
-```sh
-$ espercli pipeline stage show [OPTIONS]
-```
-##### Options
-| Name, shorthand   | Default | Description |
-|:-----------------:|:-------:|:-----------:|
-| --pipeline-id, -p | [opt]   | Pipeline ID |
-| --stage-id, -s    | [opt]   | Stage ID    |
-| --operation-id, -o| [opt]   | Operation ID |
-
-##### Example
- ```sh
- $ espercli pipeline stage show 
-
-Listing Operations for the Stage! Details:
-
-ID                 NAME    DESCRIPTION      ORDERING  ACTION         VERSION
-<operation uuid>    Jeryn   blah                    1  APP_INSTALL          2
- ``` 
- 
-## Pipeline Execution
-This sub-command is used to manually start/stop/terminate a pipeline execution. 
-
-Note:
-    If trigger is specified for a pipeline, the execution will start automatically when
-    trigger conditions are met.
+### `commandsV2`
+Multi-device / group command requests (V2 API).
 
 ```sh
-$ espercli pipeline execute
-
-usage: espercli pipeline execute [-h] {show,start,stop,terminate} ...
-
-Pipeline Execute commands
-
-optional arguments:
-  -h, --help            show this help message and exit
+# List recent requests
+espercli commandsV2 list
+espercli commandsV2 list --command reboot --command-type device
 
-sub-commands:
-  {show,start,stop,terminate}
-    show                List all Executions
-    start               Execute pipeline
-    stop                Stop a Pipeline Execution
-    terminate           Terminate a Pipeline Execution
+# Fire a command
+espercli commandsV2 command \
+  --command-type device \
+  --devices "device-name-1 device-name-2" \
+  --command reboot
 
-Usage: espercli pipeline execute
+# Check status / history
+espercli commandsV2 status --request <request-id>
+espercli commandsV2 history --device <name>
 ```
 
-#### 1. show
-List all Executions of a Pipeline
+---
 
+### `pipeline`
 ```sh
-$ espercli pipeline execute show [OPTIONS]
-```
-##### Options
-| Name, shorthand   | Default | Description |
-|:-----------------:|:-------:|:-----------:|
-| --pipeline-id, -p | [opt]   | Pipeline ID |
-
-##### Example
- ```sh
- $ espercli pipeline execute show 
-
-Enter the Pipeline ID: <uuid of pipeline>
+espercli pipeline list
+espercli pipeline show <pipeline-id>
+espercli pipeline create --name "Nightly Deploy" --no-of-stages 3
+espercli pipeline edit <pipeline-id> --name "New Name"
+espercli pipeline delete <pipeline-id>
 
-Listing Operations for the Stage! Details:
+# Stages
+espercli pipeline stage list --pipeline <id>
+espercli pipeline stage create --pipeline <id> --name "Stage 1"
 
-ID                    NAME                    DESCRIPTION    STATE       STATUS      REASON
-<pipeline uuid>       [DONT TOUCH] Jeryn CLI                 TERMINATED  TERMINATED  Dunno
-<pipeline uuid>       [DONT TOUCH] Jeryn CLI                 COMPLETED   FAILURE     Out of 1 devices, Command failed on 1 devices, with 0 inactive devices
-<pipeline uuid>       [DONT TOUCH] Jeryn CLI                 COMPLETED   FAILURE     Out of 1 devices, Command failed on 1 devices, with 0 inactive devices
- ```
-
-#### 2. start
-Start (or continue) a Manual execution of a Pipeline
-
-```sh
-$ espercli pipeline execute start [OPTIONS]
-```
-##### Options
-| Name, shorthand   | Default | Description |
-|:-----------------:|:-------:|:-----------:|
-| --pipeline-id, -p | [opt]   | Pipeline ID |
-
-##### Example
- ```sh
- $ espercli pipeline execute start 
-
-Enter the Pipeline ID: <uuid of pipeline>
-
-Pipeline execution started! Details:
-
-TITLE        DETAILS
-id           <execution uuid>
-state        RUNNING
-status       RUNNING
-reason
-client       <client uuid>
-name         [DONT TOUCH] Jeryn CLI
-description
-version      4
-started_at   2019-12-26T07:31:56.549188Z
-updated_at   2019-12-26T07:31:56.654497Z
-parent       <pipeline uuid>
- ```
- 
-#### 2. stop
-Stop an execution of a Pipeline.
-
-Note: A Stopped execution can be restarted with a `start` command
+# Operations
+espercli pipeline stage operation create --stage <id> --action APP_INSTALL
 
-```sh
-$ espercli pipeline execute stop [OPTIONS]
+# Execution
+espercli pipeline execute start   --pipeline <id>
+espercli pipeline execute stop    --pipeline <id>
+espercli pipeline execute show    --pipeline <id>
 ```
-##### Options
-| Name, shorthand   | Default | Description |
-|:-----------------:|:-------:|:-----------:|
-| --pipeline-id, -p | [opt]   | Pipeline ID |
-| --execution-id, -e| [opt]   | Execution ID |
-| --reason          | [opt]   | Reason to stop the execution |
-
-##### Example
- ```sh
- $ espercli pipeline execute stop 
-
-Enter the Pipeline ID: <uuid of pipeline>
-Enter the Execution ID: <uuid of pipeline>
-Why do you want to stop this Execution? : <give a reason>
-
-Pipeline execution Stopped! Details:
-
-TITLE        DETAILS
-id           <execution uuid>
-state        STOPPED
-status       STOPPED
-reason       <given reason>
-client       <client uuid>
-name         <pipeline name>
-description
-version      4
-started_at   2019-12-26T07:31:56.549188Z
-updated_at   2019-12-26T07:31:56.654497Z
-parent       <pipeline uuid>
- ```
-
-#### 3. terminate
-Terminate an execution of a Pipeline.
-
-Note: A terminated pipeline cant be restarted again.
 
-```sh
-$ espercli pipeline execute terminate [OPTIONS]
-```
-##### Options
-| Name, shorthand   | Default | Description |
-|:-----------------:|:-------:|:-----------:|
-| --pipeline-id, -p | [opt]   | Pipeline ID |
-| --execution-id, -e| [opt]   | Execution ID |
-| --reason          | [opt]   | Reason to stop the execution |
-
-##### Example
- ```sh
- $ espercli pipeline execute terminate 
-
-Enter the Pipeline ID: <uuid of pipeline>
-Enter the Execution ID: <uuid of pipeline>
-Why do you want to terminate this Execution? : <give a reason>
-
-Pipeline execution Stopped! Details:
-
-TITLE        DETAILS
-id           <execution uuid>
-state        TERMINATED
-status       TERMINATED
-reason       <given reason>
-client       <uuid>
-name         <pipeline name>
-description
-version      4
-started_at   2019-12-26T07:31:56.549188Z
-updated_at   2019-12-26T07:31:56.654497Z
-parent       <uuid>
- ```
-
-#### 4. continue
-Continue a Stopped execution of a Pipeline.
+---
 
-```sh
-$ espercli pipeline execute continue [OPTIONS]
-```
-##### Options
-| Name, shorthand   | Default | Description |
-|:-----------------:|:-------:|:-----------:|
-| --pipeline-id, -p | [opt]   | Pipeline ID |
-| --execution-id, -e| [opt]   | Execution ID |
-
-##### Example
- ```sh
- $ espercli pipeline execute continue 
-
-Enter the Pipeline ID: <uuid of pipeline>
-Enter the Execution ID: <uuid of pipeline>
-
-Pipeline execution Started! Details:
-
-TITLE        DETAILS
-id           <execution uuid>
-state        RUNNING
-status       RUNNING
-reason       <given reason>
-client       <uuid>
-name         <pipeline name>
-description
-version      4
-started_at   2019-12-26T07:31:56.549188Z
-updated_at   2019-12-26T07:31:56.654497Z
-parent       <uuid>
- ```
-
-
-### **Content**
-Content command can be used to list, show, upload, modify and delete content.
+### `content`
 ```sh
-$ espercli content [SUB-COMMANDS]
+espercli content list
+espercli content show <content-id>
+espercli content upload <path/to/file>
+espercli content modify <content-id> --tags "tag1 tag2" --description "..."
+espercli content delete <content-id>       # requires confirmation
 ```
-#### Sub commands
-#### 1. list
-List all contents.
-Pagination used to limit the number of results, default is 20 results per page.
-```sh
-$ espercli content list [OPTIONS]
-```
-##### Options
-| Name, shorthand | Default| Description|
-| -------------   |:------:|:----------|
-| --limit, -l     |20      | Number of results to return per page |
-| --offset, -i    |0       | The initial index from which to return the results |
-| --search, -s    |        | Searches by name/tags/description |
-| --json, -j      |        | Render result in JSON format |
-
-##### Example
-```sh
-$ espercli content list -l 5
-Total Number of Contents: 52
-  ID  NAME                                            DESCRIPTION    TAGS            SIZE  CREATED ON
-  61  ss.png                                                         []              9768  2020-10-23 08:52:09.506002+00:00
-  59  gh.jpg                                                         []             79604  2020-10-23 06:29:24.743538+00:00
-  58  {CDE0DFC1-79F7-4D5A-A777-6D376F417F60}.png.jpg                 []             60712  2020-10-23 06:28:32.900106+00:00
-  57  1.har                                                          []            208492  2020-10-23 02:12:58.777150+00:00
-  49  download.jpg                                                   ['download']    7947  2020-10-21 05:27:41.413469+00:00
-
-$ espercli content list -l 2 -i 1 -s screenshot
-Total Number of Contents: 3
-  ID  NAME                                      DESCRIPTION    TAGS      SIZE  CREATED ON
-  51  Screenshot 2020-06-05 at 11.28.51 AM.png                 []       24037  2020-10-21 07:13:21.466780+00:00
-  50  Screenshot 2020-04-07 at 8.46.31 AM.png                  []       14202  2020-10-21 07:03:07.817152+00:00
-```
 
-#### 2. show
-Show the details of a content. Here, `content_id` is required to show the content information.
+---
 
+### `token`
 ```sh
-$ espercli content show [OPTIONS] [content_id]
+espercli token show
+espercli token renew
 ```
-##### Options
-| Name, shorthand | Default| Description|
-| -------------   |:------:|:----------|
-| --json, -j      |        | Render result in JSON format |
-
-##### Example
-```sh
-$ espercli content show 61
-
-TITLE        DETAILS
-id           61
-name         ss.png
-is_dir       False
-kind         image/png
-hash         _hNmIrB4PnQ4ov77q1PccbPcuGrqH2TDUOpcvjlDv5g
-size         9768
-path         /root/
-permissions  777
-tags         []
-description
-created      2020-10-23 08:52:09.506002+00:00
-modified     2020-10-23 08:52:09.506024+00:00
-enterprise   f44373cb-1800-43c6-aab3-c81f8b1f435c
-owner        bindya
 
-```
-#### 3. upload
-Upload content. Here, content file path is required to upload the content.
+---
 
+### `enterprise`
 ```sh
-$ espercli content upload [OPTIONS] [content_file]
+espercli enterprise show
+espercli enterprise set-active
 ```
-##### Options
-| Name, shorthand | Default| Description|
-| -------------   |:------:|:----------|
-| --json, -j      |        | Render result in JSON format |
-
-##### Example
-```sh
-$ espercli content upload screen.png
-Uploading......: 100%|█████████▉| 144k/144k [00:13<00:00, 11.2kB/s, file=screen.png]
-
-TITLE        DETAILS
-id           71
-name         screen.png
-is_dir       False
-kind         image/png
-hash         kbFYPWUuFfy4bZHEMHPcLioNee7amOCkMR4crYTE-lQ
-size         147483
-path         /root/
-permissions  777
-tags         []
-description
-created      2020-10-28 04:04:18.394138+00:00
-modified     2020-10-28 04:04:18.394161+00:00
-enterprise   f44373cb-1800-43c6-aab3-c81f8b1f435c
-owner        bindya
-
-```
 
-#### 4. modify
-Modify a content information. Here, `content_id` is required to modify the content and only the tags and description can be modified.
+---
 
-```sh
-$ espercli content modify [OPTIONS] [content_id]
-```
-##### Options
-| Name, shorthand   | Default| Description|
-| ------------------|:------:|:----------|
-| --tags, -t        |        | List of tags, space separated|
-| --description, -d |        | Description |
-| --json, -j        |        | Render result in JSON format |
-
-##### Example
+### `telemetry`
 ```sh
-$ espercli content modify 61 -t screenshots new -d screenshot
-
-TITLE        DETAILS
-id           61
-name         ss.png
-is_dir       False
-kind         image/png
-hash         _hNmIrB4PnQ4ov77q1PccbPcuGrqH2TDUOpcvjlDv5g
-size         9768
-path         /root/
-permissions  777
-tags         ['screenshots', 'new']
-description  screenshot
-created      2020-10-23 08:52:09.506002+00:00
-modified     2020-10-23 08:57:44.658128+00:00
-enterprise   f44373cb-1800-43c6-aab3-c81f8b1f435c
-owner        bindya
-
+espercli telemetry get-data \
+  --device <name> \
+  --metric battery-level \
+  --last 24 \
+  --period hour \
+  --statistic avg
 ```
-
-
-#### 5. delete
-Delete a content. Here, `content_id` is required to delete the content.
 
-```sh
-$ espercli content delete [content_id]
-```
+---
 
-##### Example
+### `secureadb`
 ```sh
-$ espercli content delete 61
-Content with id 61 deleted successfully.
+espercli secureadb connect --device <name>
 ```
-### **Commands V2**
-Commands V2.0 is used to list the command requests, statuses, fire different actions on devices or groups like ping, reboot etc. It provides advanced device command capabilities like queuing, support for offline devices, dynamic device set for commands and command history.
 
-```sh
-$ espercli commandsV2 [SUB-COMMANDS]
-```
-#### Sub commands
-#### 1. list
-List and filter command requests.
-```sh
-$ espercli commandsV2 list [OPTIONS]
-```
-##### Options
-| Name, shorthand     | Default| Description|
-| ------------------- |:------:|:----------|
-| --command_type, -ct |        | Filter by type of command request |
-| --device, -d        |        | Filter by device name |
-| --device_type, -dt  |        | Filter by device type |
-| --command, -c       |        | Filter by command name |
-| --limit, -l         | 10     | Number of results to return |
-| --json, -j          |        | Render result in JSON format |
-
-##### Example
-```sh
-$ espercli commandsV2 list
-Total Number of Command Requests: 12916
-
-RQUEST ID                             COMMAND           ISSUED BY    COMMAND TYPE    CREATED ON
-5054d1d0-45c4-4a7d-b897-798af05edf75  WIPE              aneesha      DEVICE          2020-10-21 12:12:51.662946+00:00
-b1256407-1c10-43b7-9f90-85b835430f08  UPDATE_HEARTBEAT  aneesha      DEVICE          2020-10-21 12:11:32.603833+00:00
-d41fcaff-0d7a-4151-9c87-2b1ba471b8ea  SET_KIOSK_APP     aneesha      DEVICE          2020-10-21 12:11:26.573396+00:00
-03d903d5-6236-424c-832c-350a0feb00a4  WIPE              aneesha      DEVICE          2020-10-21 12:07:19.449655+00:00
-101482a9-5094-453e-affc-3985334403cf  WIPE              aneesha      DEVICE          2020-10-21 12:05:56.745790+00:00
-8b42dc16-7162-4a0a-bdcf-8265eab1b65e  UPDATE_HEARTBEAT  aneesha      DEVICE          2020-10-21 12:05:22.767914+00:00
-4d2731e5-6a89-4826-9b3c-9cdaff0002dc  SET_KIOSK_APP     aneesha      DEVICE          2020-10-21 12:05:17.930897+00:00
-6276758a-1f40-425e-bd3d-7159b53ca850  WIPE              aneesha      DEVICE          2020-10-21 12:03:37.860293+00:00
-3ddd792d-2fbd-418d-a27a-4339fccf8e44  WIPE              mihir        DEVICE          2020-10-21 11:56:24.611128+00:00
-773a72f8-3bdd-4176-975e-e5473f2ee42a  SET_APP_STATE     mihir        DEVICE          2020-10-21 11:52:16.225932+00:00
-
-$ espercli commandsV2 list -ct device -d DEV-ELOP-W57Z -dt active -c set_kiosk_app -l 2
-Total Number of Command Requests: 21
-
-RQUEST ID                             COMMAND        ISSUED BY    COMMAND TYPE    CREATED ON
-4854906d-6f76-4b58-88f9-295d481f02e4  SET_KIOSK_APP  alok         DEVICE          2020-10-14 09:05:52.430365+00:00
-6c540c8e-3078-4f9c-85b1-d2d39f3dec5a  SET_KIOSK_APP  alok         DEVICE          2020-10-14 09:05:10.526865+00:00
-```
+---
 
-#### 2. status
+### Utility commands
 
-List and filter command request status.
 ```sh
-$ espercli commandsV2 status [OPTIONS]
+espercli context          # show active environment, enterprise, device, app, group
+espercli about            # show CLI version
+espercli completion zsh   # install tab-completion
 ```
-##### Options
-| Name, shorthand     | Default| Description|
-| ------------------- |:------:|:----------|
-| --request, -r       |        | Command request id |
-| --device, -d        |        | Filter by device name |
-| --state, -s         |        | Filter by command state |
-| --limit, -l         | 10     | Number of results to return |
-| --json, -j          |        | Render result in JSON format |
-
-##### Example
-```sh
-$ espercli commandsV2 status -r b39da444-6adf-4241-a4b4-2831dbbee264 
-Total Number of Statuses: 1
 
-STATUS ID                             DEVICE ID                             STATE            REASON
-45e35f8a-bd47-4a9d-9991-e88fd5ba58ca  2d110b9c-6f65-430f-869d-fefb2a576dd3  Command Success
+---
 
-$ espercli commandsV2 status -r b39da444-6adf-4241-a4b4-2831dbbee264 -d DEV-ELOP-W57Z -s success -l 1
+## Global flags
 
-Total Number of Statuses: 1
+| Flag | Short | Description |
+|---|---|---|
+| `--verbose` | `-v` | Enable debug logging |
+| `--no-color` | | Disable colour output (useful for piping / CI) |
 
-STATUS ID                             DEVICE ID                             STATE            REASON
-45e35f8a-bd47-4a9d-9991-e88fd5ba58ca  2d110b9c-6f65-430f-869d-fefb2a576dd3  Command Success
+---
 
-```
+## Output formats
 
-#### 3. history
+Every listing and detail command supports `--json` / `-j` for machine-readable output:
 
-Get and filter command history.
 ```sh
-$ espercli commandsV2 history [OPTIONS]
+espercli device list --json | jq '.[].id'
+espercli app show <id> --json
 ```
-##### Options
-| Name, shorthand     | Default| Description|
-| ------------------- |:------:|:----------|
-| --device, -d        |        | Device name |
-| --state, -s         |        | Filter by command state |
-| --limit, -l         | 10     | Number of results to return |
-| --json, -j          |        | Render result in JSON format |
-
-##### Example
-```sh
-$ espercli commandsV2 history -d  DEV-ELOP-W57Z -l 3
-Total Number of Statuses: 343
 
-STATUS ID                             DEVICE ID                             STATE              REASON
-b9f57e76-7ef4-49db-b43e-9c0d7be3c0b1  2d110b9c-6f65-430f-869d-fefb2a576dd3  Command Scheduled  Command scheduled by None
-05f42317-f768-4949-bece-cdafecd8e443  2d110b9c-6f65-430f-869d-fefb2a576dd3  Command Scheduled  Command scheduled by None
-5730a1ff-d65d-4658-a69e-9973b8244930  2d110b9c-6f65-430f-869d-fefb2a576dd3  Command Scheduled  Command scheduled by None
+---
 
-$ espercli commandsV2 history -d  DEV-ELOP-W57Z -s success -l 2
-Total Number of Statuses: 150
+## Error messages
 
-STATUS ID                             DEVICE ID                             STATE            REASON
-7d9a3382-e1ac-4483-847c-198de35ca92c  2d110b9c-6f65-430f-869d-fefb2a576dd3  Command Success  DPC Update Command issued successfully
-553f44e7-0a2b-4269-90a5-04e111e225c4  2d110b9c-6f65-430f-869d-fefb2a576dd3  Command Success  DPC Update Command issued successfully
+Mistyped a command? The CLI shows the relevant help page inline — no need to re-run with `--help`:
 
 ```
-#### 4. command
-
-Create a command request for devices or groups.
+$ espercli device lst
 
-```sh
-$ espercli commandsV2 command [OPTIONS]
-```
-##### Options
-| Name, shorthand     | Default| Description|
-| ------------------- |:------:|:----------|
-| --command_type, -ct |        | Command type |
-| --devices, -d       |        | List of device names, space separated |
-| --groups, -g        |        | List of group ids, space separated |
-| --device_type, -dt  | active | Device type |
-| --command, -c       |        | Command name |
-| --schedule, -s      |immediate| Schedule type |
-| --schedule_name, -sn|        | Schedule name |
-| --start, -st        |        | Schedule start date-time |
-| --end, -en          |        | Schedlue end date-time |
-| --time_type, -tt    |        | Time type |
-| --window_start, -ws |        | Window start time |
-| --window_end, -we   |        | Window end time |
-| --days, -dy         | all    | List of days, space separated |
-| --app_state, -as    |        | App state |
-| --app_version, -av  |        | App version |
-| --custom_config, -cs|        | Custom settings config |
-| --device_alias, -dv |        | Device alias name |
-| --message, -m       |        | Message |
-| --package_name, -pk |        | Package name |
-| --policy_url, -po   |        | Policy url |
-| --state, -se        |        | State |
-| --wifi_access_points, -wap|        | Wifi access points |
-| --json, -j          |        | Render result in JSON format |
-
-##### Commands 
-
-| Command Name     |  Description     | Details           |
-| -----------------|:----------------:|:------------------|
-| reboot           | Reboot a device  |                   |
-| update_heartbeat | Ping a device    |                   |
-| update_device_config | Push additional configurations to the Device | Requires `custom_config` where `custom_config` is the data with the custom settings config |
-| install          | Install an app on a device | Requires `app_version` where `app_version` is the version id of app uploaded on Esper |
-| uninstall        |  Uninstall an app from device | Requires `package_name` where `package_name` is the name of the app package uploaded on Esper |
-| set_new_policy   |  Apply policy on device | Requires `policy_url` where `policy_url` is the URL to the policy |
-| add_wifi_ap      | Add wifi access points for device | Requires `wifi_access_points` where `wifi_access_points` is the data with access points |
-| remove_wifi_ap   | Remove Wifi access points for device | Requires `wifi_access_points` where `wifi_access_points` is the data with access points |
-| set_kiosk_app     | Command to set the Kiosk app for a device | Requires `package_name` where `package_name` is the name of the app package uploaded on Esper |
-| set_device_lockdown_state | Set lockdown state for a device | Requires `state` and `message` where `state` is LOCKED/UNLOCKED and `message` is the message to be added with command |
-| set_app_state     | Set the state of an app | Requries `app_state` and `package_name` where `app_state` is the state of app - SHOW/HIDE/DISABLE and `package_name` is the name of the app package uploaded on Esper |
-| wipe              | Wipes the device | | 
-| update_latest_dpc | Prompt device to update the DPC app to the latest versions | | 
-
-
-##### Example
-```sh
-$ espercli commandsV2 command -c update_heartbeat -ct device -d DEV-ELOP-UULA
-
-TITLE          DETAILS
-Id             ba36ea4d-1744-43a9-a42f-8e60d24946f8
-Command        UPDATE_HEARTBEAT
-Command Args   {}
-Command Type   DEVICE
-Devices        ['babc9cf5-2dbb-4382-bb9d-d6245941db35']
-Groups         []
-Device Type    active
-Status         []
-Issued by      bindya
-Schedule       IMMEDIATE
-Schedule Args
-Created On     2020-10-21 12:18:04.194833+00:00
-
-$ espercli commandsV2 command -c set_app_state -as SHOW -pk com.asana.app -ct device -d DEV-ELOP-W57Z -dt all -s window -sn scheduling -st 2020-10-21T20:15:00Z -en 2020-10-21T21:15:00Z -ws 13:15:00 -we 14:15:00 -tt device
-
-TITLE          DETAILS
-Id             4c91045c-1113-424c-9f57-baae7d8dd0a7
-Command        SET_APP_STATE
-Command Args   {'package_name': 'com.asana.app', 'app_state': 'SHOW'}
-Command Type   DEVICE
-Devices        ['2d110b9c-6f65-430f-869d-fefb2a576dd3']
-Groups         []
-Device Type    all
-Status         Command Scheduled
-Issued by      bindya
-Schedule       WINDOW
-Schedule Args  {'name': 'scheduling', 'start_datetime': '2020-10-21 20:15:00+00:00', 'end_datetime': '2020-10-21 21:15:00+00:00', 'time_type': 'device', 'window_start_time': '13:15:00', 'window_end_time': '14:15:00', 'days': ['All days']}
-Created On     2020-10-21 14:07:27.601095+00:00
+╭─ Error ────────────────────────────────────╮
+│ ✗  No such command 'lst'. Did you mean 'list'?  │
+╰────────────────────────────────────────────╯
 
+ Usage: espercli device [OPTIONS] COMMAND [ARGS]...
 
+╭─ Commands ─────────────────────────╮
+│ list         List devices          │
+│ show         Show device details   │
+│ set-active   Set active device     │
+│ unset-active Clear active device   │
+╰────────────────────────────────────╯
 ```
 
+---
 
-We are always in active development and we try our best to keep our documentation up to date. However, if you end up ahead of time you can check our latest documentation on [Github](https://github.com/esper-io/esper-cli).
+## License
 
-If you face any issue with CLI usage, we recommend you to reach out to [Esper Dev Support](https://docs.esper.io/home/support.html)
+Apache 2.0 — see [LICENSE](LICENSE).

--- a/README.md
+++ b/README.md
@@ -106,6 +106,10 @@ espercli device show <name> --active          # show + set as active device
 
 espercli device set-active --name <name>      # set active device
 espercli device unset-active                  # clear active device
+
+espercli device report <name>                 # HTML dashboard (opens in browser)
+espercli device report <name> --output ./report.html   # write to specific path
+espercli device report <name> --no-open       # write file without opening browser
 ```
 
 ---

--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@ A command-line tool for the [Esper](https://esper.io) API — manage devices, ap
 
 Built with [Typer](https://typer.tiangolo.com) and [Rich](https://github.com/Textualize/rich) for a modern CLI experience: colour-coded output, tab-completion, inline help on errors, and auto-pagination.
 
+Also ships a **Claude Code skill** (`/esper`) so you can manage your fleet in plain English directly from your AI coding session — no syntax required.
+
 ---
 
 ## Requirements
@@ -342,6 +344,50 @@ $ espercli device lst
 │ unset-active Clear active device   │
 ╰────────────────────────────────────╯
 ```
+
+---
+
+## Claude Code skill (`/esper`)
+
+The repo includes a [Claude Code](https://claude.ai/code) slash command that gives you a natural-language interface to your Esper fleet. Instead of remembering CLI syntax, just describe what you want.
+
+### Setup
+
+**Option A — project skill (automatic when you clone):**
+
+The skill is already at `.claude/commands/esper.md` in this repo. Open the project in Claude Code and `/esper` is available immediately — no install step.
+
+**Option B — user skill (available in every project):**
+
+Copy the skill to your global commands directory so it works outside this repo too:
+
+```sh
+mkdir -p ~/.claude/commands
+cp .claude/commands/esper.md ~/.claude/commands/esper.md
+```
+
+### Usage
+
+Type `/esper` in Claude Code followed by what you want in plain English:
+
+```
+/esper show me all inactive devices
+/esper reboot the warehouse group
+/esper what apps are installed on ezra pixel
+/esper upload build/app-release.apk and set it as the active app
+/esper show battery telemetry for ezra pixel over the last 24 hours
+/esper which devices have version abc-123 installed
+```
+
+Or just `/esper` with no argument — it checks your active context and waits for direction.
+
+### What it does
+
+- Runs `espercli context` first so it knows your active environment, device, and group
+- Translates natural language into the right `espercli` commands and runs them
+- Presents results as a clean summary, not raw CLI output
+- Asks for confirmation before any destructive action (wipe, delete) regardless of how you phrase the request
+- Asks a clarifying question if the target is ambiguous rather than guessing
 
 ---
 

--- a/esper/cli/__init__.py
+++ b/esper/cli/__init__.py
@@ -1,0 +1,1 @@
+# Typer-based CLI for espercli

--- a/esper/cli/app.py
+++ b/esper/cli/app.py
@@ -1,0 +1,214 @@
+"""
+Main Typer application — entry point for ``espercli``.
+
+Wires all sub-apps, builds the nested pipeline/stage/operation/execute
+hierarchy, and registers the global --verbose / --no-color flags.
+"""
+from __future__ import annotations
+
+import typer
+from rich.console import Console
+from rich.panel import Panel
+from rich.table import Table
+
+# ── Sub-app imports ──────────────────────────────────────────────────────────
+from esper.cli.configure import app as configure_app
+from esper.cli.device import app as device_app
+from esper.cli.device_command import app as device_command_app
+from esper.cli.group_command import app as group_command_app
+from esper.cli.installs import app as installs_app
+from esper.cli.status import app as status_app
+from esper.cli.application import app as application_app
+from esper.cli.version import app as version_app
+from esper.cli.enterprise import app as enterprise_app
+from esper.cli.group import app as group_app
+from esper.cli.pipeline import app as pipeline_app
+from esper.cli.stage import app as stage_app
+from esper.cli.operation import app as operation_app
+from esper.cli.execute import app as execute_app
+from esper.cli.token import app as token_app
+from esper.cli.content import app as content_app
+from esper.cli.commandsv2 import app as commandsv2_app
+from esper.cli.secureadb import app as secureadb_app
+from esper.cli.telemetry import app as telemetry_app
+from esper.cli.output import disable_color, install_rich_errors
+from esper.cli.state import state
+
+# ── Install Rich error rendering ASAP ───────────────────────────────────────
+# Must run before Click/Typer parse any arguments so every UsageError (typos,
+# missing args, unknown options) is rendered inside a Rich panel.
+install_rich_errors()
+
+# ── Wire the pipeline hierarchy ──────────────────────────────────────────────
+#   espercli pipeline stage operation <cmd>
+stage_app.add_typer(operation_app, name="operation")
+#   espercli pipeline stage <cmd>  /  espercli pipeline execute <cmd>
+pipeline_app.add_typer(stage_app, name="stage")
+pipeline_app.add_typer(execute_app, name="execute")
+
+# ── Root application ─────────────────────────────────────────────────────────
+main = typer.Typer(
+    help="Esper CLI — command line tool for the Esper APIs",
+    no_args_is_help=True,
+    rich_markup_mode="rich",
+)
+
+
+@main.callback()
+def _global_options(
+    verbose: bool = typer.Option(
+        False, "--verbose", "-v",
+        help="Enable debug logging.",
+        is_eager=True,
+        expose_value=True,
+    ),
+    no_color: bool = typer.Option(
+        False, "--no-color",
+        help="Disable coloured output (useful for piping).",
+        is_eager=True,
+        expose_value=True,
+    ),
+) -> None:
+    """Esper CLI — command line tool for the Esper APIs."""
+    if verbose:
+        state.set_debug(True)
+    if no_color:
+        disable_color()
+
+
+# ── Built-in utility commands ────────────────────────────────────────────────
+
+@main.command("context")
+def show_context() -> None:
+    """
+    Show the current active context at a glance.
+
+    Displays the configured environment, enterprise ID, and whatever
+    active device / application / group is set in the local store.
+    """
+    from esper.ext.db_wrapper import DBWrapper
+
+    _console = Console()
+    db = DBWrapper(state.creds)
+
+    config      = db.get_configure()    or {}
+    device      = db.get_device()       or {}
+    application = db.get_application()  or {}
+    group       = db.get_group()        or {}
+
+    tbl = Table(show_header=False, box=None, padding=(0, 3))
+    tbl.add_column("key",   style="bold cyan", no_wrap=True)
+    tbl.add_column("value", no_wrap=False)
+
+    def _val(v: str | None) -> str:
+        return v if v else "[dim]none[/dim]"
+
+    env        = config.get("environment")
+    raw_eid = config.get("enterprise_id") or ""
+    # enterprise_id may be stored as a full URL like
+    # "http://.../enterprise/UUID/"  — extract the trailing UUID if so
+    parts = [p for p in raw_eid.split("/") if p]
+    eid = parts[-1] if parts else None
+    dev_label  = device.get("name") or device.get("id")
+    app_label  = application.get("id")
+    grp_label  = group.get("name") or group.get("id")
+
+    if not env:
+        tbl.add_row(
+            "Status",
+            "[bold red]Not configured[/bold red] — run [cyan]espercli configure[/cyan] first",
+        )
+    else:
+        tbl.add_row("Environment",   _val(env))
+        tbl.add_row("Enterprise ID", _val(eid))
+        tbl.add_row("Active Device", _val(dev_label))
+        tbl.add_row("Active App",    _val(app_label))
+        tbl.add_row("Active Group",  _val(grp_label))
+
+    _console.print(
+        Panel(tbl, title="[bold]Esper CLI Context[/bold]", border_style="bold blue", expand=False)
+    )
+
+
+@main.command("about")
+def show_version() -> None:
+    """Show the espercli version and build info."""
+    try:
+        from importlib.metadata import version as _pkg_version
+        ver = _pkg_version("espercli")
+    except Exception:
+        ver = "0.0.16"
+    Console().print(f"[bold]espercli[/bold] version [cyan]{ver}[/cyan]")
+
+
+@main.command("completion")
+def install_completion(
+    shell: str = typer.Argument(
+        ...,
+        help="Shell to install completion for: bash, zsh, fish, powershell",
+    ),
+) -> None:
+    """
+    Install tab-completion for your shell.
+
+    Run once, then restart your terminal (or re-source your shell config):
+
+        espercli completion zsh
+        espercli completion bash
+        espercli completion fish
+    """
+    import os
+    import sys
+    from typer._completion_shared import install as _install
+
+    supported = {"bash", "zsh", "fish", "powershell", "pwsh"}
+    if shell.lower() not in supported:
+        Console(stderr=True).print(
+            Panel(
+                f"[bold red]✗[/bold red]  [bold]{shell}[/bold] is not supported.\n\n"
+                f"[dim]Supported shells: {', '.join(sorted(supported))}[/dim]",
+                title="[bold red]Error[/bold red]",
+                border_style="red",
+                expand=False,
+                padding=(0, 1),
+            ),
+            file=sys.stderr,
+        )
+        raise typer.Exit(1)
+
+    # Bypass shellingham — pass the shell name directly.
+    detected_shell, path = _install(shell=shell.lower())
+    Console().print(
+        f"[bold green]✓[/bold green]  [bold]{detected_shell}[/bold] completion "
+        f"installed in [cyan]{path}[/cyan]\n\n"
+        "[dim]Restart your terminal or run:[/dim]  "
+        f"[cyan]source {'~/.zshrc' if shell == 'zsh' else '~/.bashrc'}[/cyan]"
+    )
+
+
+# ── Register all sub-apps ────────────────────────────────────────────────────
+main.add_typer(configure_app,      name="configure")
+main.add_typer(device_app,         name="device")
+main.add_typer(device_command_app, name="device-command")
+main.add_typer(group_command_app,  name="group-command")
+main.add_typer(installs_app,       name="installs")
+main.add_typer(status_app,         name="status")
+main.add_typer(application_app,    name="app")
+main.add_typer(version_app,        name="version")
+main.add_typer(enterprise_app,     name="enterprise")
+main.add_typer(group_app,          name="group")
+main.add_typer(pipeline_app,       name="pipeline")
+main.add_typer(token_app,          name="token")
+main.add_typer(content_app,        name="content")
+main.add_typer(commandsv2_app,     name="commandsV2")
+main.add_typer(secureadb_app,      name="secureadb")
+main.add_typer(telemetry_app,      name="telemetry")
+
+
+def main_entry() -> None:
+    """Console-script entry point registered in setup.py."""
+    main()
+
+
+if __name__ == "__main__":
+    main_entry()

--- a/esper/cli/app.py
+++ b/esper/cli/app.py
@@ -31,6 +31,11 @@ from esper.cli.content import app as content_app
 from esper.cli.commandsv2 import app as commandsv2_app
 from esper.cli.secureadb import app as secureadb_app
 from esper.cli.telemetry import app as telemetry_app
+from esper.cli.fleet import app as fleet_app
+from esper.cli.heartbeat import app as heartbeat_app
+from esper.cli.location import app as location_app
+from esper.cli.policy import app as policy_app
+from esper.cli.user import app as user_app
 from esper.cli.output import disable_color, install_rich_errors
 from esper.cli.state import state
 
@@ -203,6 +208,11 @@ main.add_typer(content_app,        name="content")
 main.add_typer(commandsv2_app,     name="commandsV2")
 main.add_typer(secureadb_app,      name="secureadb")
 main.add_typer(telemetry_app,      name="telemetry")
+main.add_typer(fleet_app,          name="fleet")
+main.add_typer(heartbeat_app,      name="heartbeat")
+main.add_typer(location_app,       name="location")
+main.add_typer(policy_app,         name="policy")
+main.add_typer(user_app,           name="user")
 
 
 def main_entry() -> None:

--- a/esper/cli/application.py
+++ b/esper/cli/application.py
@@ -70,7 +70,7 @@ def app_list(
         if all_results:
             from esper.cli.output import console as _console
             results = []
-            page_size, cur_offset = 100, 0
+            page_size, cur_offset = 20, 0
             with _console.status("[dim]Fetching all applications…[/dim]", spinner="dots"):
                 while True:
                     page = application_client.get_all_applications(

--- a/esper/cli/application.py
+++ b/esper/cli/application.py
@@ -1,0 +1,328 @@
+"""
+Application commands — replaces esper/controllers/application/application.py.
+`espercli app list/show/upload/download/delete/set-active/unset-active`
+"""
+import os
+import random
+import time
+from pathlib import Path
+from typing import Optional
+
+import requests
+import typer
+from esperclient.rest import ApiException
+from tqdm import tqdm
+
+from esper.cli.completions import app_name_complete
+from esper.cli.output import render
+from esper.cli.state import state, validate_creds, parse_error_message
+from esper.controllers.enums import OutputFormat
+from esper.ext.api_client import APIClient
+from esper.ext.db_wrapper import DBWrapper
+
+app = typer.Typer(help="Application commands")
+
+
+# ---------------------------------------------------------------------------
+# Shared helpers
+# ---------------------------------------------------------------------------
+
+def _application_basic_response(application, fmt=OutputFormat.TABULATED):
+    valid_keys = [
+        "id", "application_name", "package_name", "developer",
+        "category", "content_rating", "compatibility",
+    ]
+    if fmt == OutputFormat.JSON:
+        return {k: v for k, v in application.to_dict().items() if k in valid_keys}
+    title, details = "TITLE", "DETAILS"
+    return [{title: k, details: v} for k, v in application.to_dict().items() if k in valid_keys]
+
+
+# ---------------------------------------------------------------------------
+# Commands
+# ---------------------------------------------------------------------------
+
+@app.command("list")
+def app_list(
+    name: Optional[str] = typer.Option(None, "--name", "-n", help="Application name"),
+    package: Optional[str] = typer.Option(None, "--package", "-p", help="Package name"),
+    limit: int = typer.Option(20, "--limit", "-l", help="Results per page"),
+    offset: int = typer.Option(0, "--offset", "-i", help="Initial index"),
+    all_results: bool = typer.Option(
+        False, "--all", "-A",
+        help="Fetch ALL applications, auto-paginating (ignores --limit / --offset).",
+    ),
+    json_output: bool = typer.Option(False, "--json", "-j", help="Render result in JSON format"),
+):
+    """List applications in the enterprise."""
+    validate_creds()
+    db = DBWrapper(state.creds)
+    application_client = APIClient(db.get_configure()).get_application_api_client()
+    enterprise_id = db.get_enterprise_id()
+
+    kwargs: dict = {"is_hidden": False}
+    if name:
+        kwargs["application_name"] = name
+    if package:
+        kwargs["package_name"] = package
+
+    try:
+        if all_results:
+            from esper.cli.output import console as _console
+            results = []
+            page_size, cur_offset = 100, 0
+            with _console.status("[dim]Fetching all applications…[/dim]", spinner="dots"):
+                while True:
+                    page = application_client.get_all_applications(
+                        enterprise_id, limit=page_size, offset=cur_offset, **kwargs
+                    )
+                    results.extend(page.results)
+                    if len(results) >= page.count or not page.results:
+                        break
+                    cur_offset += page_size
+
+            class _FR:
+                def __init__(self, r):
+                    self.results = r
+                    self.count = len(r)
+            response = _FR(results)
+        else:
+            response = application_client.get_all_applications(
+                enterprise_id, limit=limit, offset=offset, **kwargs
+            )
+    except ApiException as e:
+        state.log.error(f"[application-list] Failed to list applications: {e}")
+        render(f"ERROR: {parse_error_message(e)}")
+        raise typer.Exit(1)
+
+    render(f"Total Number of Applications: {response.count}")
+    if not json_output:
+        label = {"id": "ID", "name": "NAME", "package": "PACKAGE NAME"}
+        applications = [
+            {
+                label["id"]: a.id,
+                label["name"]: a.application_name,
+                label["package"]: a.package_name,
+            }
+            for a in response.results
+        ]
+        render(applications, format=OutputFormat.TABULATED.value, headers="keys", tablefmt="plain")
+    else:
+        applications = [
+            {"id": a.id, "name": a.application_name, "package": a.package_name}
+            for a in response.results
+        ]
+        render(applications, format=OutputFormat.JSON.value)
+
+
+@app.command("show")
+def app_show(
+    application_id: str = typer.Argument(..., help="Application ID"),
+    active: bool = typer.Option(
+        False, "--active", "-a", help="Set as the active application"
+    ),
+    json_output: bool = typer.Option(False, "--json", "-j", help="Render result in JSON format"),
+):
+    """Show application details (and optionally set as active)."""
+    validate_creds()
+    db = DBWrapper(state.creds)
+    application_client = APIClient(db.get_configure()).get_application_api_client()
+    enterprise_id = db.get_enterprise_id()
+
+    try:
+        response = application_client.get_application(application_id, enterprise_id)
+    except ApiException as e:
+        state.log.error(f"[application-show] Failed to show application: {e}")
+        render(f"ERROR: {parse_error_message(e)}")
+        raise typer.Exit(1)
+
+    if active:
+        db.set_application({"id": application_id})
+
+    if not json_output:
+        render(_application_basic_response(response), format=OutputFormat.TABULATED.value, headers="keys", tablefmt="plain")
+    else:
+        render(_application_basic_response(response, OutputFormat.JSON), format=OutputFormat.JSON.value)
+
+
+@app.command("upload")
+def app_upload(
+    application_file: str = typer.Argument(..., help="Path to the APK/application file"),
+    json_output: bool = typer.Option(False, "--json", "-j", help="Render result in JSON format"),
+):
+    """Upload an application."""
+    validate_creds()
+    db = DBWrapper(state.creds)
+    application_client = APIClient(db.get_configure()).get_application_api_client()
+    enterprise_id = db.get_enterprise_id()
+
+    try:
+        filesize = os.path.getsize(application_file)
+        random_no = random.randint(1, 50)
+        response = None
+        with tqdm(total=int(filesize), unit="B", unit_scale=True, miniters=1,
+                  desc="Uploading......", unit_divisor=1024) as pbar:
+            for i in range(100):
+                if i == random_no:
+                    response = application_client.upload(enterprise_id, application_file)
+                time.sleep(0.07)
+                pbar.set_postfix(file=Path(application_file).name, refresh=False)
+                pbar.update(int(filesize / 100))
+        application = response.application
+    except ApiException as e:
+        state.log.error(f"[application-upload] Failed to upload application: {e}")
+        render(f"ERROR: {parse_error_message(e)}")
+        raise typer.Exit(1)
+
+    valid_keys = ["id", "application_name", "package_name", "developer",
+                  "category", "content_rating", "compatibility"]
+
+    if not json_output:
+        title, details = "TITLE", "DETAILS"
+        renderable = [{title: k, details: v}
+                      for k, v in application.to_dict().items() if k in valid_keys]
+        if application and application.versions:
+            version = application.versions[0]
+            renderable.append({title: "version_id", details: version.id})
+            renderable.append({title: "version_code", details: version.version_code})
+            if hasattr(version, "version_name") and version.version_name:
+                renderable.append({title: "version_name", details: version.version_name})
+            elif hasattr(version, "build_number") and version.build_number:
+                renderable.append({title: "build_number", details: version.build_number})
+        render(renderable, format=OutputFormat.TABULATED.value, headers="keys", tablefmt="plain")
+    else:
+        renderable = {k: v for k, v in application.to_dict().items() if k in valid_keys}
+        if application and application.versions:
+            version = application.versions[0]
+            renderable["version_id"] = version.id
+            renderable["version_code"] = version.version_code
+            if hasattr(version, "version_name") and version.version_name:
+                renderable["version_name"] = version.version_name
+            elif hasattr(version, "build_number") and version.build_number:
+                renderable["build_number"] = version.build_number
+        render(renderable, format=OutputFormat.JSON.value)
+
+
+@app.command("download")
+def app_download(
+    version_id: str = typer.Argument(..., help="Version ID to download"),
+    application: Optional[str] = typer.Option(
+        None, "--app", "-a", help="Application ID (default: active application)",
+        shell_complete=app_name_complete,
+    ),
+    dest: Optional[str] = typer.Option(None, "--dest", "-d", help="Destination file path"),
+):
+    """Download an application version."""
+    validate_creds()
+    db = DBWrapper(state.creds)
+    application_client = APIClient(db.get_configure()).get_application_api_client()
+    enterprise_id = db.get_enterprise_id()
+
+    if application:
+        application_id = application
+    else:
+        active_app = db.get_application()
+        if not active_app or not active_app.get("id"):
+            render("There is no active application.")
+            raise typer.Exit(1)
+        application_id = active_app.get("id")
+
+    if not dest:
+        render("Destination file path cannot be empty.")
+        raise typer.Exit(1)
+
+    try:
+        response = application_client.get_app_version(version_id, application_id, enterprise_id)
+    except ApiException as e:
+        state.log.error(f"[app-download] Failed to get version: {e}")
+        render(f"ERROR: {parse_error_message(e)}")
+        raise typer.Exit(1)
+
+    url = response.app_file
+    file_size = int(response.size_in_mb * 1024 * 1024)
+    pbar = tqdm(total=file_size, initial=0, unit="B", unit_scale=True, desc="Downloading......")
+    req = requests.get(url, stream=True)
+    with open(dest, "ab") as f:
+        for chunk in req.iter_content(chunk_size=1024):
+            if chunk:
+                f.write(chunk)
+                pbar.update(1024)
+                time.sleep(0.001)
+    pbar.close()
+
+
+@app.command("delete")
+def app_delete(
+    application_id: str = typer.Argument(..., help="Application ID to delete"),
+    yes: bool = typer.Option(False, "--yes", "-y", help="Skip confirmation prompt"),
+):
+    """Delete an application."""
+    if not yes:
+        typer.confirm(
+            f"Delete application {application_id}? This cannot be undone.",
+            abort=True,
+        )
+    validate_creds()
+    db = DBWrapper(state.creds)
+    application_client = APIClient(db.get_configure()).get_application_api_client()
+    enterprise_id = db.get_enterprise_id()
+
+    try:
+        application_client.delete_application(application_id, enterprise_id)
+        render(f"Application with id {application_id} deleted successfully")
+        active_app = db.get_application()
+        if active_app and active_app.get("id") == application_id:
+            db.unset_application()
+    except ApiException as e:
+        state.log.debug(f"[application-delete] Failed to delete application: {e}")
+        render(f"ERROR: {parse_error_message(e)}")
+        raise typer.Exit(1)
+
+
+@app.command("set-active")
+def app_set_active(
+    app_id: Optional[str] = typer.Option(None, "--id", "-i", help="Application ID"),
+    json_output: bool = typer.Option(False, "--json", "-j", help="Render result in JSON format"),
+):
+    """Set or show the active application."""
+    validate_creds()
+    db = DBWrapper(state.creds)
+    application_client = APIClient(db.get_configure()).get_application_api_client()
+    enterprise_id = db.get_enterprise_id()
+
+    if app_id:
+        application_id = app_id
+    else:
+        active_app = db.get_application()
+        if active_app is None or active_app.get("id") is None:
+            render("There is no active application.")
+            raise typer.Exit(1)
+        application_id = active_app.get("id")
+
+    try:
+        response = application_client.get_application(application_id, enterprise_id)
+        db.set_application({"id": application_id})
+    except ApiException as e:
+        state.log.error(f"[application-active] Failed to show active application: {e}")
+        render(f"ERROR: {parse_error_message(e)}")
+        raise typer.Exit(1)
+
+    if not json_output:
+        render(_application_basic_response(response), format=OutputFormat.TABULATED.value, headers="keys", tablefmt="plain")
+    else:
+        render(_application_basic_response(response, OutputFormat.JSON), format=OutputFormat.JSON.value)
+
+
+@app.command("unset-active")
+def app_unset_active():
+    """Unset the current active application."""
+    validate_creds()
+    db = DBWrapper(state.creds)
+
+    application = db.get_application()
+    if application is None or application.get("id") is None:
+        render("There is no active application.")
+        raise typer.Exit(1)
+
+    db.unset_application()
+    render(f"Unset the active application {application.get('id')}")

--- a/esper/cli/commandsv2.py
+++ b/esper/cli/commandsv2.py
@@ -1,0 +1,530 @@
+"""
+CommandsV2 commands — replaces esper/controllers/commandsV2/commandsV2.py.
+`espercli commandsv2 list/status/history/command`
+"""
+import json
+from typing import Optional
+
+import typer
+from esperclient import V0CommandRequest
+from esperclient.rest import ApiException
+
+from esper.cli.completions import (
+    command_enum_complete,
+    command_type_complete,
+    command_state_complete,
+    device_name_complete,
+    device_type_complete,
+    schedule_type_complete,
+    days_complete,
+    time_type_complete,
+)
+from esper.cli.output import render
+from esper.cli.state import state, validate_creds, parse_error_message
+from esper.controllers.enums import (
+    OutputFormat,
+    CommandEnum,
+    CommandState,
+    CommandRequestTypeEnum,
+    CommandDeviceTypeEnum,
+    WeekDays,
+)
+from esper.ext.api_client import APIClient
+from esper.ext.db_wrapper import DBWrapper
+
+app = typer.Typer(help="Fire commands to devices or groups")
+
+
+# ---------------------------------------------------------------------------
+# Shared helpers
+# ---------------------------------------------------------------------------
+
+def _request_basic_response(request, fmt=OutputFormat.TABULATED):
+    if request.schedule_args is None:
+        schedule_args = None
+    else:
+        schedule_args = {
+            "name": request.schedule_args.name,
+            "start_datetime": str(request.schedule_args.start_datetime),
+            "end_datetime": str(request.schedule_args.end_datetime),
+            "time_type": request.schedule_args.time_type,
+            "window_start_time": str(request.schedule_args.window_start_time),
+            "window_end_time": str(request.schedule_args.window_end_time),
+            "days": request.schedule_args.days,
+        }
+
+    command_args = {
+        k[1:]: v for k, v in request.command_args.__dict__.items() if v is not None
+    }
+
+    state_val = request.status[0].state if request.status else None
+    issued_by = request.issued_by.split("'")[-2]
+
+    if fmt == OutputFormat.TABULATED:
+        title, details = "TITLE", "DETAILS"
+        return [
+            {title: "Id", details: request.id},
+            {title: "Command", details: request.command},
+            {title: "Command Args", details: command_args},
+            {title: "Command Type", details: request.command_type},
+            {title: "Devices", details: request.devices},
+            {title: "Groups", details: request.groups},
+            {title: "Device Type", details: request.device_type},
+            {title: "Status", details: state_val},
+            {title: "Issued by", details: issued_by},
+            {title: "Schedule", details: request.schedule},
+            {title: "Schedule Args", details: schedule_args},
+            {title: "Created On", details: request.created_on},
+        ]
+    return {
+        "id": request.id,
+        "command": request.command,
+        "command_type": request.command_type,
+        "command_args": command_args,
+        "devices": request.devices,
+        "groups": request.groups,
+        "device_type": request.device_type,
+        "status": str(request.status),
+        "issued_by": request.issued_by,
+        "schedule": request.schedule,
+        "schedule_args": schedule_args,
+        "created_on": str(request.created_on),
+    }
+
+
+def _render_status_response(status_response, limit: int, json_output: bool):
+    render(f"Total Number of Statuses: {status_response.count}")
+    if not json_output:
+        label = {"id": "STATUS ID", "device": "DEVICE ID", "state": "STATE", "reason": "REASON"}
+        statuses = [
+            {
+                label["id"]: s.id,
+                label["device"]: s.device.split("/")[-2],
+                label["state"]: s.state,
+                label["reason"]: s.reason,
+            }
+            for s in status_response.results[:limit]
+        ]
+        render(statuses, format=OutputFormat.TABULATED.value, headers="keys", tablefmt="plain")
+    else:
+        statuses = [
+            {
+                "id": s.id,
+                "request_id": s.request,
+                "device_id": s.device.split("/")[-2],
+                "state": s.state,
+                "reason": s.reason,
+                "created_on": str(s.created_on),
+                "updated_on": str(s.updated_on),
+            }
+            for s in status_response.results[:limit]
+        ]
+        render(statuses, format=OutputFormat.JSON.value)
+
+
+# ---------------------------------------------------------------------------
+# Commands
+# ---------------------------------------------------------------------------
+
+@app.command("list")
+def commandsv2_list(
+    command_type: Optional[str] = typer.Option(
+        None, "--command-type", "-ct",
+        help=f"Filter by command type ({', '.join(CommandRequestTypeEnum.choice_list_lower())})",
+        shell_complete=command_type_complete,
+    ),
+    device: Optional[str] = typer.Option(
+        None, "--device", "-d", help="Filter by device name",
+        shell_complete=device_name_complete,
+    ),
+    device_type: Optional[str] = typer.Option(
+        None, "--device-type", "-dt",
+        help=f"Filter by device type ({', '.join(CommandDeviceTypeEnum.choice_list_lower())})",
+        shell_complete=device_type_complete,
+    ),
+    command: Optional[str] = typer.Option(
+        None, "--command", "-c",
+        help=f"Filter by command name ({', '.join(CommandEnum.choice_list_lower())})",
+        shell_complete=command_enum_complete,
+    ),
+    limit: int = typer.Option(10, "--limit", "-l", help="Number of results"),
+    json_output: bool = typer.Option(False, "--json", "-j", help="Render result in JSON format"),
+):
+    """List command requests."""
+    validate_creds()
+    db = DBWrapper(state.creds)
+    device_client = APIClient(db.get_configure()).get_device_api_client()
+    commandsv2_client = APIClient(db.get_configure()).get_commandsV2_api_client()
+    enterprise_id = db.get_enterprise_id()
+
+    kwargs = {}
+    if command_type:
+        kwargs["command_type"] = command_type.upper()
+
+    if device:
+        try:
+            search_response = device_client.get_all_devices(enterprise_id, limit=1, offset=0, name=device)
+            if not search_response.results:
+                render(f"Device does not exist with name {device}")
+                raise typer.Exit(1)
+            kwargs["devices"] = search_response.results[0].id
+        except ApiException as e:
+            state.log.error(f"[commandsv2-list] Failed to list devices: {e}")
+            render(f"ERROR: {parse_error_message(e)}")
+            raise typer.Exit(1)
+
+    if device_type:
+        kwargs["device_type"] = device_type
+    if command:
+        kwargs["command"] = command.upper()
+
+    try:
+        response = commandsv2_client.list_command_request(enterprise_id, **kwargs)
+    except ApiException as e:
+        state.log.error(f"[commandsv2-list] Failed to list command requests: {e}")
+        render(f"ERROR: {parse_error_message(e)}")
+        raise typer.Exit(1)
+
+    render(f"Total Number of Command Requests: {response.count}")
+    if not json_output:
+        label = {"id": "REQUEST ID", "command": "COMMAND", "issued_by": "ISSUED BY",
+                 "command_type": "COMMAND TYPE", "created_on": "CREATED ON"}
+        commandreqs = []
+        for req in response.results[:limit]:
+            issued_by_raw = req.issued_by.replace("'", '"')
+            try:
+                issued_by = json.loads(issued_by_raw).get("username", issued_by_raw)
+            except Exception:
+                issued_by = req.issued_by
+            commandreqs.append({
+                label["id"]: req.id,
+                label["command"]: req.command,
+                label["issued_by"]: issued_by,
+                label["command_type"]: req.command_type,
+                label["created_on"]: req.created_on,
+            })
+        render(commandreqs, format=OutputFormat.TABULATED.value, headers="keys", tablefmt="plain")
+    else:
+        commandreqs = []
+        for req in response.results[:limit]:
+            sa = req.schedule_args
+            schedule_args = None if sa is None else {
+                "name": sa.name,
+                "start_datetime": str(sa.start_datetime),
+                "end_datetime": str(sa.end_datetime),
+                "time_type": sa.time_type,
+                "window_start_time": str(sa.window_start_time),
+                "window_end_time": str(sa.window_end_time),
+                "days": sa.days,
+            }
+            ca = req.command_args
+            command_args = {
+                "app_state": ca.app_state,
+                "app_version": ca.app_version,
+                "custom_settings_config": ca.custom_settings_config,
+                "device_alias_name": ca.device_alias_name,
+                "message": ca.message,
+                "package_name": ca.package_name,
+                "policy_url": ca.policy_url,
+                "state": ca.state,
+                "wifi_access_points": ca.wifi_access_points,
+            }
+            commandreqs.append({
+                "id": req.id,
+                "command": req.command,
+                "command_type": req.command_type,
+                "issued_by": req.issued_by,
+                "devices": req.devices,
+                "device_type": req.device_type,
+                "groups": req.groups,
+                "command_args": command_args,
+                "schedule": req.schedule,
+                "schedule_args": schedule_args,
+                "created_on": str(req.created_on),
+                "status": str(req.status),
+            })
+        render(commandreqs, format=OutputFormat.JSON.value)
+
+
+@app.command("status")
+def commandsv2_status(
+    request_id: Optional[str] = typer.Option(None, "--request", "-r", help="Command Request ID"),
+    device: Optional[str] = typer.Option(
+        None, "--device", "-d", help="Filter by device name",
+        shell_complete=device_name_complete,
+    ),
+    state_filter: Optional[str] = typer.Option(
+        None, "--state", "-s",
+        help=f"Filter by command state ({', '.join(CommandState.choice_list_lower())})",
+        shell_complete=command_state_complete,
+    ),
+    limit: int = typer.Option(10, "--limit", "-l", help="Number of results"),
+    json_output: bool = typer.Option(False, "--json", "-j", help="Render result in JSON format"),
+):
+    """Show command request status."""
+    validate_creds()
+    db = DBWrapper(state.creds)
+    device_client = APIClient(db.get_configure()).get_device_api_client()
+    commandsv2_client = APIClient(db.get_configure()).get_commandsV2_api_client()
+    enterprise_id = db.get_enterprise_id()
+
+    if not request_id:
+        render("request id is not given")
+        raise typer.Exit(1)
+
+    kwargs = {}
+    if device:
+        try:
+            search_response = device_client.get_all_devices(enterprise_id, limit=1, offset=0, name=device)
+            if not search_response.results:
+                render(f"Device does not exist with name {device}")
+                raise typer.Exit(1)
+            kwargs["device"] = search_response.results[0].id
+        except ApiException as e:
+            state.log.error(f"[commandsv2-status] Failed to list devices: {e}")
+            render(f"ERROR: {parse_error_message(e)}")
+            raise typer.Exit(1)
+
+    if state_filter:
+        kwargs["state"] = CommandState[state_filter.upper()].value
+
+    try:
+        response = commandsv2_client.get_command_request_status(enterprise_id, request_id, **kwargs)
+    except ApiException as e:
+        state.log.error(f"[commandsv2-status] Failed to get status for {request_id}: {e}")
+        render(f"ERROR: {parse_error_message(e)}")
+        raise typer.Exit(1)
+
+    _render_status_response(response, limit, json_output)
+
+
+@app.command("history")
+def commandsv2_history(
+    device: Optional[str] = typer.Option(
+        None, "--device", "-d", help="Device name",
+        shell_complete=device_name_complete,
+    ),
+    state_filter: Optional[str] = typer.Option(
+        None, "--state", "-s",
+        help=f"Filter by command state ({', '.join(CommandState.choice_list_lower())})",
+        shell_complete=command_state_complete,
+    ),
+    limit: int = typer.Option(10, "--limit", "-l", help="Number of results"),
+    json_output: bool = typer.Option(False, "--json", "-j", help="Render result in JSON format"),
+):
+    """Show device command history."""
+    validate_creds()
+    db = DBWrapper(state.creds)
+    commandsv2_client = APIClient(db.get_configure()).get_commandsV2_api_client()
+    device_client = APIClient(db.get_configure()).get_device_api_client()
+    enterprise_id = db.get_enterprise_id()
+
+    if not device:
+        render("Device name is not given")
+        raise typer.Exit(1)
+
+    try:
+        search_response = device_client.get_all_devices(enterprise_id, limit=1, offset=0, name=device)
+        if not search_response.results:
+            render(f"Device does not exist with name {device}")
+            raise typer.Exit(1)
+        device_id = search_response.results[0].id
+    except ApiException as e:
+        state.log.error(f"[commandsv2-history] Failed to list devices: {e}")
+        render(f"ERROR: {parse_error_message(e)}")
+        raise typer.Exit(1)
+
+    kwargs = {}
+    if state_filter:
+        kwargs["state"] = CommandState[state_filter.upper()].value
+
+    try:
+        response = commandsv2_client.get_device_command_history(enterprise_id, device_id, **kwargs)
+    except ApiException as e:
+        state.log.error(f"[commandsv2-history] Failed to get history for {device_id}: {e}")
+        render(f"ERROR: {parse_error_message(e)}")
+        raise typer.Exit(1)
+
+    _render_status_response(response, limit, json_output)
+
+
+@app.command("command")
+def commandsv2_command(
+    command_type: Optional[str] = typer.Option(
+        None, "--command-type", "-ct",
+        help="Command type: device, group, or dynamic",
+        shell_complete=command_type_complete,
+    ),
+    devices: Optional[str] = typer.Option(
+        None, "--devices", "-d",
+        help="Space-separated list of device names",
+    ),
+    groups: Optional[str] = typer.Option(
+        None, "--groups", "-g",
+        help="Space-separated list of group IDs",
+    ),
+    device_type: str = typer.Option(
+        "active", "--device-type", "-dt",
+        help="Device type: active, inactive, or all",
+        shell_complete=device_type_complete,
+    ),
+    command: Optional[str] = typer.Option(
+        None, "--command", "-c",
+        help=f"Command name ({', '.join(CommandEnum.choice_list_lower())})",
+        shell_complete=command_enum_complete,
+    ),
+    schedule: str = typer.Option(
+        "immediate", "--schedule", "-s",
+        help="Schedule type: immediate, window, or recurring",
+        shell_complete=schedule_type_complete,
+    ),
+    schedule_name: Optional[str] = typer.Option(None, "--schedule-name", "-sn", help="Schedule name"),
+    start_datetime: Optional[str] = typer.Option(None, "--start", "-st", help="Start date-time"),
+    end_datetime: Optional[str] = typer.Option(None, "--end", "-en", help="End date-time"),
+    time_type: str = typer.Option(
+        "console", "--time-type", "-tt", help="Time type: console or device",
+        shell_complete=time_type_complete,
+    ),
+    window_start_time: Optional[str] = typer.Option(None, "--window-start", "-ws", help="Window start time"),
+    window_end_time: Optional[str] = typer.Option(None, "--window-end", "-we", help="Window end time"),
+    days: str = typer.Option(
+        "all", "--days", "-dy",
+        help="Comma-separated days: monday..sunday or all",
+        shell_complete=days_complete,
+    ),
+    app_state: Optional[str] = typer.Option(None, "--app-state", "-as", help="App state"),
+    app_version: Optional[str] = typer.Option(None, "--app-version", "-av", help="App version"),
+    custom_settings_config: Optional[str] = typer.Option(None, "--custom-config", "-cs", help="Custom settings config (JSON)"),
+    device_alias_name: Optional[str] = typer.Option(None, "--device-alias", "-dv", help="Device alias name"),
+    message: Optional[str] = typer.Option(None, "--message", "-m", help="Message"),
+    package_name: Optional[str] = typer.Option(None, "--package-name", "-pk", help="Package name"),
+    policy_url: Optional[str] = typer.Option(None, "--policy-url", "-po", help="Policy URL"),
+    cmd_state: Optional[str] = typer.Option(None, "--state", "-se", help="State"),
+    wifi_access_points: Optional[str] = typer.Option(None, "--wifi-access-points", "-wap", help="Wifi access points"),
+    json_output: bool = typer.Option(False, "--json", "-j", help="Render result in JSON format"),
+):
+    """Fire commands to devices and groups."""
+    validate_creds()
+    db = DBWrapper(state.creds)
+    commandsv2_client = APIClient(db.get_configure()).get_commandsV2_api_client()
+    enterprise_id = db.get_enterprise_id()
+
+    if not command:
+        render("command cannot be empty.")
+        raise typer.Exit(1)
+
+    if not command_type:
+        render("command type cannot be empty.")
+        raise typer.Exit(1)
+
+    command_upper = command.upper()
+    command_type_upper = command_type.upper()
+
+    device_list = devices.split() if devices else []
+    group_list = groups.split() if groups else []
+
+    if command_type_upper in (CommandRequestTypeEnum.DEVICE.name, CommandRequestTypeEnum.DYNAMIC.name):
+        if not device_list:
+            render("devices cannot be empty.")
+            raise typer.Exit(1)
+
+    if command_type_upper == CommandRequestTypeEnum.GROUP.name:
+        if not group_list:
+            render("groups cannot be empty.")
+            raise typer.Exit(1)
+
+    # Build schedule_args
+    req_days = days.split(",") if days else ["all"]
+    resolved_days = []
+    for day in req_days:
+        day = day.strip()
+        if day == "all":
+            resolved_days.append(WeekDays.ALL_DAYS.value)
+        else:
+            resolved_days.append(WeekDays[day.upper()].value)
+
+    schedule_args = None
+    if schedule_name:
+        schedule_args = {
+            "name": schedule_name,
+            "start_datetime": start_datetime,
+            "end_datetime": end_datetime,
+            "window_start_time": window_start_time,
+            "window_end_time": window_end_time,
+            "time_type": time_type,
+            "days": resolved_days,
+        }
+
+    # Resolve device names → IDs
+    device_client = APIClient(db.get_configure()).get_device_api_client()
+    device_ids = []
+    for device_name in device_list:
+        try:
+            search_response = device_client.get_all_devices(enterprise_id, limit=1, offset=0, name=device_name)
+            if not search_response.results:
+                render(f"Device does not exist with name {device_name}")
+                raise typer.Exit(1)
+            device_ids.append(search_response.results[0].id)
+        except ApiException as e:
+            state.log.error(f"Failed to list devices: {e}")
+            render(f"ERROR: {parse_error_message(e)}")
+            raise typer.Exit(1)
+
+    # Validate group IDs
+    resolved_group_ids = []
+    if group_list:
+        group_client = APIClient(db.get_configure()).get_group_api_client()
+        for group_id in group_list:
+            try:
+                group_client.get_group_by_id(group_id, enterprise_id)
+                resolved_group_ids.append(group_id)
+            except ApiException as e:
+                state.log.error(f"Group does not exist with id {group_id}: {e}")
+                render(f"ERROR: {parse_error_message(e)}")
+                raise typer.Exit(1)
+
+    # Parse custom config JSON
+    parsed_custom_config = None
+    if custom_settings_config:
+        try:
+            parsed_custom_config = json.loads(custom_settings_config)
+        except Exception as e:
+            state.log.error(f"Could not parse JSON custom_settings_config: {e}")
+            render(f"ERROR: Invalid JSON for custom_settings_config")
+            raise typer.Exit(1)
+
+    command_args_raw = {
+        "app_state": app_state,
+        "app_version": app_version,
+        "custom_settings_config": parsed_custom_config,
+        "device_alias_name": device_alias_name,
+        "message": message,
+        "package_name": package_name,
+        "policy_url": policy_url,
+        "state": cmd_state,
+        "wifi_access_points": wifi_access_points,
+    }
+    command_args = {k: v for k, v in command_args_raw.items() if v is not None}
+
+    command_request = V0CommandRequest(
+        command_type=command_type_upper,
+        devices=device_ids,
+        device_type=device_type,
+        command=command_upper,
+        command_args=command_args,
+        schedule=schedule.upper(),
+        schedule_args=schedule_args,
+        groups=resolved_group_ids if resolved_group_ids else None,
+    )
+
+    try:
+        response = commandsv2_client.create_command(enterprise_id, command_request)
+    except ApiException as e:
+        state.log.error(f"[commandsv2-command] Failed to fire command {command_upper}: {e}")
+        render(f"ERROR: {parse_error_message(e)}")
+        raise typer.Exit(1)
+
+    if not json_output:
+        render(_request_basic_response(response), format=OutputFormat.TABULATED.value, headers="keys", tablefmt="plain")
+    else:
+        render(_request_basic_response(response, OutputFormat.JSON), format=OutputFormat.JSON.value)

--- a/esper/cli/completions.py
+++ b/esper/cli/completions.py
@@ -1,0 +1,174 @@
+"""
+Tab-completion helpers for espercli.
+
+Static completions use known enum values — always available even before
+the CLI is configured.
+
+Dynamic completions query the Esper API at completion time (i.e. when the
+user presses <TAB>).  They fail silently — if credentials are missing or
+the API is unreachable the shell simply shows no suggestions instead of
+printing an error.
+
+Usage in command files::
+
+    from esper.cli.completions import device_name_complete, device_state_complete
+
+    @app.command("list")
+    def device_list(
+        state_filter: Optional[str] = typer.Option(
+            None, "--state", "-s",
+            shell_complete=device_state_complete,
+        ),
+        ...
+    ):
+        ...
+"""
+from __future__ import annotations
+
+# ── Static completion factories ───────────────────────────────────────────────
+
+def _static(values: list[str]):
+    """Return a Click shell-completion callback for a fixed *values* list."""
+    def _complete(ctx, param, incomplete: str):
+        from click.shell_completion import CompletionItem
+        low = incomplete.lower()
+        return [CompletionItem(v) for v in values if v.lower().startswith(low)]
+    return _complete
+
+
+# ── Static completions ────────────────────────────────────────────────────────
+
+#: Device lifecycle states (lowercase, as accepted by --state)
+device_state_complete = _static([
+    "active", "inactive", "disabled", "onboarded", "registered",
+    "provisioning_begin", "google_play_configuration",
+    "policy_application_in_progress", "onboarding_in_progress",
+    "onboarding_failed", "wipe_in_progress", "apps_installed",
+    "branding_processed", "permission_policy_processed",
+    "device_policy_processed", "device_settings_processed",
+    "security_policy_processed", "phone_policy_processed",
+    "custom_settings_processed",
+])
+
+#: V2 command names (lowercase)
+command_enum_complete = _static([
+    "reboot", "set_new_policy", "update_heartbeat", "wipe",
+    "install", "uninstall", "update_latest_dpc", "set_kiosk_app",
+    "set_device_lockdown_state", "set_app_state", "add_wifi_ap",
+    "remove_wifi_ap", "update_device_config",
+])
+
+#: Command request types
+command_type_complete = _static(["device", "group", "dynamic"])
+
+#: V2 command lifecycle states
+command_state_complete = _static([
+    "queued", "initiate", "acknowledge", "in_progress",
+    "timeout", "success", "failure", "scheduled", "cancelled",
+])
+
+#: Device type filter for V2 commands
+device_type_complete = _static(["active", "inactive", "all"])
+
+#: Schedule types for V2 commands
+schedule_type_complete = _static(["immediate", "window", "recurring"])
+
+#: Schedule days
+days_complete = _static([
+    "all", "monday", "tuesday", "wednesday",
+    "thursday", "friday", "saturday", "sunday",
+])
+
+#: Schedule time type
+time_type_complete = _static(["console", "device"])
+
+#: legacy-format flag values
+legacy_format_complete = _static(["true", "false"])
+
+#: GMS flag values
+gms_complete = _static(["true", "false"])
+
+#: Telemetry period values
+period_complete = _static(["custom", "today", "yesterday", "weekly", "monthly"])
+
+#: Telemetry statistic values
+statistic_complete = _static(["avg", "max", "min", "sum"])
+
+
+# ── Dynamic completion helpers ────────────────────────────────────────────────
+
+def _load_db():
+    """Return a configured DBWrapper, or *None* if credentials aren't set up."""
+    try:
+        import os
+        from tinydb import TinyDB
+        from esper.ext.db_wrapper import DBWrapper
+
+        creds_path = os.path.expanduser("~/.esper/db/creds.json")
+        if not os.path.exists(creds_path):
+            return None
+        db = DBWrapper(TinyDB(creds_path))
+        if not db.get_configure():
+            return None
+        return db
+    except Exception:
+        return None
+
+
+def device_name_complete(ctx, param, incomplete: str):
+    """Complete device names (alias or hardware name) from the API."""
+    from click.shell_completion import CompletionItem
+    try:
+        db = _load_db()
+        if db is None:
+            return []
+        from esper.ext.api_client import APIClient
+        enterprise_id = db.get_enterprise_id()
+        client = APIClient(db.get_configure()).get_device_api_client()
+        kwargs = {"name": incomplete} if incomplete else {}
+        resp = client.get_all_devices(enterprise_id, limit=30, offset=0, **kwargs)
+        items = []
+        for d in resp.results:
+            label = d.alias_name or d.device_name
+            hint = d.device_name if d.alias_name else None
+            items.append(CompletionItem(label, help=hint))
+        return items
+    except Exception:
+        return []
+
+
+def group_name_complete(ctx, param, incomplete: str):
+    """Complete group names from the API."""
+    from click.shell_completion import CompletionItem
+    try:
+        db = _load_db()
+        if db is None:
+            return []
+        from esper.ext.api_client import APIClient
+        enterprise_id = db.get_enterprise_id()
+        client = APIClient(db.get_configure()).get_group_api_client()
+        kwargs = {"name": incomplete} if incomplete else {}
+        resp = client.get_all_groups(enterprise_id, limit=30, offset=0, **kwargs)
+        return [CompletionItem(g.name) for g in resp.results]
+    except Exception:
+        return []
+
+
+def app_name_complete(ctx, param, incomplete: str):
+    """Complete application names (returns app ID, shows name as hint) from the API."""
+    from click.shell_completion import CompletionItem
+    try:
+        db = _load_db()
+        if db is None:
+            return []
+        from esper.ext.api_client import APIClient
+        enterprise_id = db.get_enterprise_id()
+        client = APIClient(db.get_configure()).get_application_api_client()
+        kwargs = {"application_name": incomplete, "is_hidden": False} if incomplete else {"is_hidden": False}
+        resp = client.get_all_applications(enterprise_id, limit=30, offset=0, **kwargs)
+        return [
+            CompletionItem(a.id, help=a.application_name)
+            for a in resp.results
+        ]
+    except Exception:
+        return []

--- a/esper/cli/completions.py
+++ b/esper/cli/completions.py
@@ -103,11 +103,11 @@ def _load_db():
         import os
         from tinydb import TinyDB
         from esper.ext.db_wrapper import DBWrapper
+        from esper.cli.state import CREDS_FILE
 
-        creds_path = os.path.expanduser("~/.esper/db/creds.json")
-        if not os.path.exists(creds_path):
+        if not os.path.exists(CREDS_FILE):
             return None
-        db = DBWrapper(TinyDB(creds_path))
+        db = DBWrapper(TinyDB(CREDS_FILE))
         if not db.get_configure():
             return None
         return db

--- a/esper/cli/configure.py
+++ b/esper/cli/configure.py
@@ -1,0 +1,92 @@
+"""
+Configure command — replaces esper/controllers/configure.py.
+Embedded at the root level: `espercli configure`
+"""
+import json
+from http import HTTPStatus
+from typing import Optional
+
+import typer
+from esperclient.rest import ApiException
+
+from esper.cli.output import render
+from esper.cli.state import state
+from esper.controllers.enums import OutputFormat
+from esper.ext.api_client import APIClient
+from esper.ext.db_wrapper import DBWrapper
+
+app = typer.Typer(help="Configure credentials for the Esper.io API Service")
+
+
+@app.callback(invoke_without_command=True)
+def configure(
+    set_creds: bool = typer.Option(
+        False, "--set", "-s", help="Create or update credentials for the Esper.io API Service"
+    ),
+    list_creds: bool = typer.Option(
+        False, "--list", "-l", help="List stored credentials"
+    ),
+    json_output: bool = typer.Option(
+        False, "--json", "-j", help="Render result in JSON format"
+    ),
+):
+    """Configure (or display) Esper.io API credentials."""
+    db = DBWrapper(state.creds)
+    credentials = db.get_configure()
+
+    # ------------------------------------------------------------------ set
+    if set_creds or not credentials:
+        environment = typer.prompt("Environment name")
+        api_key = typer.prompt("Esper API Key", hide_input=True)
+
+        token_client = APIClient(
+            {"api_key": api_key, "environment": environment}
+        ).get_token_api_client()
+        try:
+            response = token_client.get_token_info()
+        except ApiException as e:
+            state.log.error(f"[configure] Failed to get token info: {e}")
+            if e.status == HTTPStatus.UNAUTHORIZED:
+                render("You are not authorized, invalid API Key.")
+            else:
+                error_message = (
+                    json.loads(e.body).get("message")
+                    if e.body and json.loads(e.body).get("message")
+                    else e.reason
+                )
+                render(f"ERROR: {error_message}")
+            raise typer.Exit(1)
+
+        if response:
+            enterprise_id = response.enterprise
+        else:
+            state.log.info("[configure] API key is not associated with any enterprise.")
+            render("API key is not associated with any enterprise.")
+            raise typer.Exit(1)
+
+        credentials = {
+            "environment": environment,
+            "api_key": api_key,
+            "enterprise_id": enterprise_id,
+        }
+        db.set_configure(credentials)
+
+    # ----------------------------------------------------------------- list
+    if list_creds or credentials:
+        if not credentials:
+            render("No credentials stored. Run `espercli configure --set` to add them.")
+            raise typer.Exit(1)
+
+        if not json_output:
+            title, details = "TITLE", "DETAILS"
+            renderable = [
+                {title: "environment", details: credentials.get("environment")},
+                {title: "api_key", details: credentials.get("api_key")},
+            ]
+            render(renderable, format=OutputFormat.TABULATED.value, headers="keys", tablefmt="plain")
+        else:
+            renderable = {
+                "environment": credentials.get("environment"),
+                "api_key": credentials.get("api_key"),
+            }
+            render(renderable, format=OutputFormat.JSON.value)

--- a/esper/cli/content.py
+++ b/esper/cli/content.py
@@ -1,0 +1,252 @@
+"""
+Content commands — replaces esper/controllers/content/content.py.
+`espercli content list/show/upload/modify/delete`
+"""
+import os
+import random
+import time
+from pathlib import Path
+from typing import Optional
+
+import typer
+from esperclient.rest import ApiException
+from tqdm import tqdm
+
+from esper.cli.output import render
+from esper.cli.state import state, validate_creds, parse_error_message
+from esper.controllers.enums import OutputFormat
+from esper.ext.api_client import APIClient
+from esper.ext.db_wrapper import DBWrapper
+
+app = typer.Typer(help="Content management commands")
+
+
+# ---------------------------------------------------------------------------
+# Shared helpers
+# ---------------------------------------------------------------------------
+
+def _content_basic_response(content, fmt=OutputFormat.TABULATED):
+    enterprise_id = content.enterprise.split("/")[-2]
+    if fmt == OutputFormat.TABULATED:
+        title, details = "TITLE", "DETAILS"
+        return [
+            {title: "id", details: content.id},
+            {title: "name", details: content.name},
+            {title: "is_dir", details: content.is_dir},
+            {title: "kind", details: content.kind},
+            {title: "hash", details: content.hash},
+            {title: "size", details: content.size},
+            {title: "path", details: content.path},
+            {title: "permissions", details: content.permissions},
+            {title: "tags", details: content.tags},
+            {title: "description", details: content.description},
+            {title: "created", details: content.created},
+            {title: "modified", details: content.modified},
+            {title: "enterprise", details: enterprise_id},
+            {title: "owner", details: content.owner.username},
+        ]
+    return {
+        "id": content.id,
+        "download_url": content.download_url,
+        "name": content.name,
+        "key": content.key,
+        "is_dir": content.is_dir,
+        "kind": content.kind,
+        "hash": content.hash,
+        "size": content.size,
+        "path": content.path,
+        "permissions": content.permissions,
+        "tags": content.tags,
+        "description": content.description,
+        "created": str(content.created),
+        "modified": str(content.modified),
+        "enterprise": content.enterprise,
+        "owner": str(content.owner),
+    }
+
+
+# ---------------------------------------------------------------------------
+# Commands
+# ---------------------------------------------------------------------------
+
+@app.command("list")
+def content_list(
+    search: Optional[str] = typer.Option(None, "--search", "-s", help="Search by name/tags/description"),
+    limit: int = typer.Option(20, "--limit", "-l", help="Results per page"),
+    offset: int = typer.Option(0, "--offset", "-i", help="Initial index"),
+    json_output: bool = typer.Option(False, "--json", "-j", help="Render result in JSON format"),
+):
+    """List all content."""
+    validate_creds()
+    db = DBWrapper(state.creds)
+    content_client = APIClient(db.get_configure()).get_content_api_client()
+    enterprise_id = db.get_enterprise_id()
+
+    kwargs = {}
+    if search:
+        kwargs["search"] = search
+
+    try:
+        response = content_client.get_all_content(enterprise_id, limit=limit, offset=offset, **kwargs)
+    except ApiException as e:
+        state.log.error(f"[content-list] Failed to list contents: {e}")
+        render(f"ERROR: {parse_error_message(e)}")
+        raise typer.Exit(1)
+
+    render(f"Total Number of Contents: {response.count}")
+    if not json_output:
+        label = {"id": "ID", "name": "NAME", "description": "DESCRIPTION",
+                 "tags": "TAGS", "size": "SIZE", "created_on": "CREATED ON"}
+        contents = [
+            {
+                label["id"]: c.id,
+                label["name"]: c.name,
+                label["description"]: c.description,
+                label["tags"]: c.tags,
+                label["size"]: c.size,
+                label["created_on"]: c.created,
+            }
+            for c in response.results
+        ]
+        render(contents, format=OutputFormat.TABULATED.value, headers="keys", tablefmt="plain")
+    else:
+        contents = [
+            {
+                "id": c.id,
+                "download_url": c.download_url,
+                "name": c.name,
+                "key": c.key,
+                "is_dir": c.is_dir,
+                "kind": c.kind,
+                "hash": c.hash,
+                "size": c.size,
+                "path": c.path,
+                "permissions": c.permissions,
+                "tags": c.tags,
+                "description": c.description,
+                "created": str(c.created),
+                "modified": str(c.modified),
+                "enterprise": c.enterprise,
+                "owner": str(c.owner),
+            }
+            for c in response.results
+        ]
+        render(contents, format=OutputFormat.JSON.value)
+
+
+@app.command("show")
+def content_show(
+    content_id: str = typer.Argument(..., help="Content ID"),
+    json_output: bool = typer.Option(False, "--json", "-j", help="Render result in JSON format"),
+):
+    """Show content details."""
+    validate_creds()
+    db = DBWrapper(state.creds)
+    content_client = APIClient(db.get_configure()).get_content_api_client()
+    enterprise_id = db.get_enterprise_id()
+
+    try:
+        response = content_client.get_content(content_id, enterprise_id)
+    except ApiException as e:
+        state.log.error(f"[content-show] Failed to show content: {e}")
+        render(f"ERROR: {parse_error_message(e)}")
+        raise typer.Exit(1)
+
+    if not json_output:
+        render(_content_basic_response(response), format=OutputFormat.TABULATED.value, headers="keys", tablefmt="plain")
+    else:
+        render(_content_basic_response(response, OutputFormat.JSON), format=OutputFormat.JSON.value)
+
+
+@app.command("upload")
+def content_upload(
+    content_file: str = typer.Argument(..., help="File to upload"),
+    json_output: bool = typer.Option(False, "--json", "-j", help="Render result in JSON format"),
+):
+    """Upload content."""
+    validate_creds()
+    db = DBWrapper(state.creds)
+    content_client = APIClient(db.get_configure()).get_content_api_client()
+    enterprise_id = db.get_enterprise_id()
+
+    try:
+        filesize = os.path.getsize(content_file)
+        random_no = random.randint(1, 50)
+        response = None
+        with tqdm(total=int(filesize), unit="B", unit_scale=True, miniters=1,
+                  desc="Uploading......", unit_divisor=1024) as pbar:
+            for i in range(100):
+                if i == random_no:
+                    response = content_client.post_content(enterprise_id, content_file)
+                time.sleep(0.07)
+                pbar.set_postfix(file=Path(content_file).name, refresh=False)
+                pbar.update(int(filesize / 100))
+    except ApiException as e:
+        state.log.error(f"[content-upload] Failed to upload content: {e}")
+        render(f"ERROR: {parse_error_message(e)}")
+        raise typer.Exit(1)
+
+    if not json_output:
+        render(_content_basic_response(response), format=OutputFormat.TABULATED.value, headers="keys", tablefmt="plain")
+    else:
+        render(_content_basic_response(response, OutputFormat.JSON), format=OutputFormat.JSON.value)
+
+
+@app.command("modify")
+def content_modify(
+    content_id: str = typer.Argument(..., help="Content ID"),
+    tags: Optional[str] = typer.Option(
+        None, "--tags", "-t", help="Space-separated list of tags"
+    ),
+    description: Optional[str] = typer.Option(None, "--description", "-d", help="Description"),
+    json_output: bool = typer.Option(False, "--json", "-j", help="Render result in JSON format"),
+):
+    """Modify content tags and/or description."""
+    validate_creds()
+    db = DBWrapper(state.creds)
+    content_client = APIClient(db.get_configure()).get_content_api_client()
+    enterprise_id = db.get_enterprise_id()
+
+    data = {}
+    if tags:
+        data["tags"] = tags.split()
+    if description:
+        data["description"] = description
+
+    if not data:
+        render("Both tags and description values are empty")
+        raise typer.Exit(1)
+
+    try:
+        response = content_client.patch_content(content_id, enterprise_id, data=data)
+    except ApiException as e:
+        state.log.error(f"[content-modify] Failed to modify content: {e}")
+        render(f"ERROR: {parse_error_message(e)}")
+        raise typer.Exit(1)
+
+    if not json_output:
+        render(_content_basic_response(response), format=OutputFormat.TABULATED.value, headers="keys", tablefmt="plain")
+    else:
+        render(_content_basic_response(response, OutputFormat.JSON), format=OutputFormat.JSON.value)
+
+
+@app.command("delete")
+def content_delete(
+    content_id: str = typer.Argument(..., help="Content ID to delete"),
+    yes: bool = typer.Option(False, "--yes", "-y", help="Skip confirmation prompt"),
+):
+    """Delete content."""
+    if not yes:
+        typer.confirm(f"Delete content {content_id}? This cannot be undone.", abort=True)
+    validate_creds()
+    db = DBWrapper(state.creds)
+    content_client = APIClient(db.get_configure()).get_content_api_client()
+    enterprise_id = db.get_enterprise_id()
+
+    try:
+        content_client.delete_content(content_id, enterprise_id)
+        render(f"Content with id {content_id} deleted successfully.")
+    except ApiException as e:
+        state.log.error(f"[content-delete] Failed to delete content: {e}")
+        render(f"ERROR: {parse_error_message(e)}")
+        raise typer.Exit(1)

--- a/esper/cli/device.py
+++ b/esper/cli/device.py
@@ -2,7 +2,6 @@
 Device commands — replaces esper/controllers/device/device.py.
 `espercli device list/show/set-active/unset-active/report`
 """
-import uuid
 from typing import Optional
 
 import typer
@@ -111,7 +110,10 @@ def device_list(
             state.log.error(f"[device-list] Failed to list groups: {e}")
             render(f"ERROR: {parse_error_message(e)}")
             raise typer.Exit(1)
-        kwargs["group"] = group_id or str(uuid.uuid4())
+        if not group_id:
+            render(f"ERROR: Group not found: {group!r}")
+            raise typer.Exit(1)
+        kwargs["group"] = group_id
     if imei:
         kwargs["imei"] = imei
     if serial:
@@ -380,8 +382,8 @@ def device_report(
                     "link_speed":          wifi.get("linkSpeed"),
                     "signal_strength":     wifi.get("signalStrength"),
                 }
-        except Exception:
-            pass  # status is optional; dashboard still renders without it
+        except Exception as _e:
+            state.log.error(f"[device-report] Could not fetch device status for {device_id}: {_e}")
 
         # ── Telemetry: battery level (30 days, daily avg) ──────────────────
         def _fetch_telemetry(category: str, metric: str) -> list:
@@ -397,8 +399,11 @@ def device_report(
                 if r.status_code == 200:
                     pts = r.json().get("data", [])
                     return [{"x": p["x"][:10], "y": round(p["y"], 1)} for p in pts]
-            except Exception:
-                pass
+            except Exception as _e:
+                state.log.error(
+                    f"[device-report] Telemetry fetch failed ({category}/{metric}) "
+                    f"for {device_id}: {_e}"
+                )
             return []
 
         battery_telemetry = _fetch_telemetry("battery", "level")
@@ -433,8 +438,8 @@ def device_report(
                     "issued_by": issued_by,
                     "state":     state_val or "—",
                 })
-        except Exception:
-            pass
+        except Exception as _e:
+            state.log.error(f"[device-report] Could not fetch command history for {device_id}: {_e}")
 
         # ── Install count ──────────────────────────────────────────────────
         installs_count = 0
@@ -442,8 +447,8 @@ def device_report(
             inst_client = APIClient(config).get_install_api_client()
             inst_resp   = inst_client.get_app_installs(enterprise_id, device_id, limit=1)
             installs_count = inst_resp.count or 0
-        except Exception:
-            pass
+        except Exception as _e:
+            state.log.error(f"[device-report] Could not fetch install count for {device_id}: {_e}")
 
     # ── Build data dict ────────────────────────────────────────────────────
     data = {

--- a/esper/cli/device.py
+++ b/esper/cli/device.py
@@ -1,0 +1,288 @@
+"""
+Device commands — replaces esper/controllers/device/device.py.
+`espercli device list/show/set-active/unset-active`
+"""
+import uuid
+from typing import Optional
+
+import typer
+from esperclient.rest import ApiException
+
+from esper.cli.completions import device_state_complete, group_name_complete, gms_complete
+from esper.cli.output import render
+from esper.cli.state import state, validate_creds, parse_error_message
+from esper.controllers.enums import DeviceState, OutputFormat
+from esper.ext.api_client import APIClient
+from esper.ext.db_wrapper import DBWrapper
+
+app = typer.Typer(help="Device commands")
+
+
+# ---------------------------------------------------------------------------
+# Shared helpers
+# ---------------------------------------------------------------------------
+
+def _get_name_and_tags(device):
+    name = device.alias_name if device.alias_name else device.device_name
+    tags = ", ".join(device.tags) if device.tags else ""
+    return name, tags
+
+
+def _device_basic_response(device, fmt=OutputFormat.TABULATED):
+    valid_keys = ["id", "device_name", "alias_name", "suid", "api_level", "template_name", "is_gms"]
+    current_state = DeviceState(device.status).name
+
+    if fmt == OutputFormat.JSON:
+        renderable = {k: v for k, v in device.to_dict().items() if k in valid_keys}
+        renderable["state"] = current_state
+        renderable["tags"] = device.tags
+    else:
+        title, details = "TITLE", "DETAILS"
+        renderable = [{title: k, details: v} for k, v in device.to_dict().items() if k in valid_keys]
+        renderable.append({title: "state", details: current_state})
+        _, tags = _get_name_and_tags(device)
+        renderable.append({title: "tags", details: tags})
+    return renderable
+
+
+# ---------------------------------------------------------------------------
+# Commands
+# ---------------------------------------------------------------------------
+
+@app.command("list")
+def device_list(
+    state_filter: Optional[str] = typer.Option(
+        None, "--state", "-s",
+        help="Device state: active, inactive, disabled",
+        shell_complete=device_state_complete,
+    ),
+    name: Optional[str] = typer.Option(None, "--name", "-n", help="Device name"),
+    group: Optional[str] = typer.Option(
+        None, "--group", "-g", help="Group name",
+        shell_complete=group_name_complete,
+    ),
+    imei: Optional[str] = typer.Option(None, "--imei", "-im", help="IMEI number"),
+    serial: Optional[str] = typer.Option(None, "--serial", "-se", help="Serial number"),
+    tags: Optional[str] = typer.Option(None, "--tags", "-t", help="Tags"),
+    search: Optional[str] = typer.Option(None, "--search", help="Search device name, alias or ID"),
+    brand: Optional[str] = typer.Option(None, "--brand", "-b", help="Brand name"),
+    gms: Optional[str] = typer.Option(
+        None, "--gms", "-gm", help="GMS or not: true, false",
+        shell_complete=gms_complete,
+    ),
+    limit: int = typer.Option(20, "--limit", "-l", help="Results per page"),
+    offset: int = typer.Option(0, "--offset", "-i", help="Initial index"),
+    all_results: bool = typer.Option(
+        False, "--all", "-A",
+        help="Fetch ALL devices, auto-paginating (ignores --limit / --offset).",
+    ),
+    json_output: bool = typer.Option(False, "--json", "-j", help="Render result in JSON format"),
+):
+    """List devices in the enterprise."""
+    validate_creds()
+    db = DBWrapper(state.creds)
+    device_client = APIClient(db.get_configure()).get_device_api_client()
+    enterprise_id = db.get_enterprise_id()
+
+    kwargs = {}
+    if state_filter:
+        if state_filter.upper() not in [s.name for s in DeviceState]:
+            # match 'active'/'inactive'/'disabled' shorthand
+            mapping = {"active": "ACTIVE", "inactive": "INACTIVE", "disabled": "DISABLED"}
+            key = mapping.get(state_filter.lower())
+            if key:
+                kwargs["state"] = DeviceState[key].value
+        else:
+            kwargs["state"] = DeviceState[state_filter.upper()].value
+
+    if name:
+        kwargs["name"] = name
+    if group:
+        kw = {"name": group}
+        group_id = None
+        try:
+            group_client = APIClient(db.get_configure()).get_group_api_client()
+            search_response = group_client.get_all_groups(enterprise_id, limit=1, offset=0, **kw)
+            for g in search_response.results:
+                if g.name == group:
+                    group_id = g.id
+                    break
+        except ApiException as e:
+            state.log.error(f"[device-list] Failed to list groups: {e}")
+            render(f"ERROR: {parse_error_message(e)}")
+            raise typer.Exit(1)
+        kwargs["group"] = group_id or str(uuid.uuid4())
+    if imei:
+        kwargs["imei"] = imei
+    if serial:
+        kwargs["serial"] = serial
+    if search:
+        kwargs["search"] = search
+    if tags:
+        kwargs["tags"] = tags
+    if brand:
+        kwargs["brand"] = brand
+    if gms:
+        kwargs["is_gms"] = gms
+
+    try:
+        if all_results:
+            from esper.cli.output import console as _console
+            results = []
+            page_size, cur_offset = 100, 0
+            with _console.status("[dim]Fetching all devices…[/dim]", spinner="dots"):
+                while True:
+                    page = device_client.get_all_devices(
+                        enterprise_id, limit=page_size, offset=cur_offset, **kwargs
+                    )
+                    results.extend(page.results)
+                    if len(results) >= page.count or not page.results:
+                        break
+                    cur_offset += page_size
+            total = len(results)
+
+            class _FakeResponse:
+                count = total
+                def __init__(self, r):
+                    self.results = r
+            response = _FakeResponse(results)
+        else:
+            response = device_client.get_all_devices(enterprise_id, limit=limit, offset=offset, **kwargs)
+    except ApiException as e:
+        state.log.error(f"[device-list] Failed to list devices: {e}")
+        render(f"ERROR: {parse_error_message(e)}")
+        raise typer.Exit(1)
+
+    render(f"Number of Devices: {response.count}")
+    if not json_output:
+        devices = []
+        label = {"id": "ID", "name": "NAME", "model": "MODEL", "state": "CURRENT STATE", "tags": "TAGS"}
+        for device in response.results:
+            current_state = DeviceState(device.status).name
+            dev_name, dev_tags = _get_name_and_tags(device)
+            devices.append({
+                label["id"]: device.id,
+                label["name"]: dev_name,
+                label["model"]: device.hardware_info.get("manufacturer"),
+                label["state"]: current_state,
+                label["tags"]: dev_tags,
+            })
+        render(devices, format=OutputFormat.TABULATED.value, headers="keys", tablefmt="plain")
+    else:
+        devices = []
+        for device in response.results:
+            current_state = DeviceState(device.status).name
+            dev_name, _ = _get_name_and_tags(device)
+            devices.append({
+                "id": device.id,
+                "device": dev_name,
+                "model": device.hardware_info.get("manufacturer"),
+                "state": current_state,
+                "tags": device.tags,
+            })
+        render(devices, format=OutputFormat.JSON.value)
+
+
+@app.command("show")
+def device_show(
+    device_name: str = typer.Argument(..., help="Device name to show details for"),
+    active: bool = typer.Option(
+        False, "--active", "-a", help="Set this device as the active device"
+    ),
+    json_output: bool = typer.Option(False, "--json", "-j", help="Render result in JSON format"),
+):
+    """Show device details (and optionally set as active)."""
+    validate_creds()
+    db = DBWrapper(state.creds)
+    device_client = APIClient(db.get_configure()).get_device_api_client()
+    enterprise_id = db.get_enterprise_id()
+
+    kwargs = {"name": device_name}
+    try:
+        search_response = device_client.get_all_devices(enterprise_id, limit=1, offset=0, **kwargs)
+        if not search_response.results:
+            state.log.debug(f"[device-show] Device does not exist with name {device_name}")
+            render(f"Device does not exist with name {device_name}")
+            raise typer.Exit(1)
+        response = search_response.results[0]
+    except ApiException as e:
+        state.log.error(f"[device-show] Failed to list devices: {e}")
+        render(f"ERROR: {parse_error_message(e)}")
+        raise typer.Exit(1)
+
+    if active:
+        dev_name, _ = _get_name_and_tags(response)
+        db.set_device({"id": response.id, "name": dev_name})
+
+    if not json_output:
+        renderable = _device_basic_response(response)
+        render(renderable, format=OutputFormat.TABULATED.value, headers="keys", tablefmt="plain")
+    else:
+        renderable = _device_basic_response(response, OutputFormat.JSON)
+        render(renderable, format=OutputFormat.JSON.value)
+
+
+@app.command("set-active")
+def set_active(
+    name: Optional[str] = typer.Option(None, "--name", "-n", help="Device name"),
+    json_output: bool = typer.Option(False, "--json", "-j", help="Render result in JSON format"),
+):
+    """Set or show the active device."""
+    validate_creds()
+    db = DBWrapper(state.creds)
+    device_client = APIClient(db.get_configure()).get_device_api_client()
+    enterprise_id = db.get_enterprise_id()
+
+    if name:
+        kwargs = {"name": name}
+        try:
+            search_response = device_client.get_all_devices(enterprise_id, limit=1, offset=0, **kwargs)
+            if not search_response.results:
+                state.log.debug(f"[device-active] Device does not exist with name {name}")
+                render(f"Device does not exist with name {name}")
+                raise typer.Exit(1)
+            response = search_response.results[0]
+            dev_name, _ = _get_name_and_tags(response)
+            db.set_device({"id": response.id, "name": dev_name})
+        except ApiException as e:
+            state.log.error(f"[device-active] Failed to list devices: {e}")
+            render(f"ERROR: {parse_error_message(e)}")
+            raise typer.Exit(1)
+    else:
+        device = db.get_device()
+        if device is None or device.get("name") is None:
+            state.log.debug("[device-active] There is no active device.")
+            render("There is no active device.")
+            raise typer.Exit(1)
+
+        device_id = device.get("id")
+        try:
+            response = device_client.get_device_by_id(enterprise_id, device_id)
+        except ApiException as e:
+            state.log.error(f"[device-active] Failed to show active device: {e}")
+            render(f"ERROR: {parse_error_message(e)}")
+            raise typer.Exit(1)
+
+    if not json_output:
+        renderable = _device_basic_response(response)
+        render(renderable, format=OutputFormat.TABULATED.value, headers="keys", tablefmt="plain")
+    else:
+        renderable = _device_basic_response(response, OutputFormat.JSON)
+        render(renderable, format=OutputFormat.JSON.value)
+
+
+@app.command("unset-active")
+def unset_active():
+    """Unset the active device."""
+    validate_creds()
+    db = DBWrapper(state.creds)
+
+    device = db.get_device()
+    if device is None or device.get("name") is None:
+        state.log.debug("[device-active] There is no active device.")
+        render("There is no active device.")
+        raise typer.Exit(1)
+
+    db.unset_device()
+    state.log.debug(f"[device-active] Unset the active device {device.get('name')}")
+    render(f"Unset the active device {device.get('name')}")

--- a/esper/cli/device.py
+++ b/esper/cli/device.py
@@ -1,6 +1,6 @@
 """
 Device commands — replaces esper/controllers/device/device.py.
-`espercli device list/show/set-active/unset-active`
+`espercli device list/show/set-active/unset-active/report`
 """
 import uuid
 from typing import Optional
@@ -8,7 +8,7 @@ from typing import Optional
 import typer
 from esperclient.rest import ApiException
 
-from esper.cli.completions import device_state_complete, group_name_complete, gms_complete
+from esper.cli.completions import device_name_complete, device_state_complete, group_name_complete, gms_complete
 from esper.cli.output import render
 from esper.cli.state import state, validate_creds, parse_error_message
 from esper.controllers.enums import DeviceState, OutputFormat
@@ -286,3 +286,197 @@ def unset_active():
     db.unset_device()
     state.log.debug(f"[device-active] Unset the active device {device.get('name')}")
     render(f"Unset the active device {device.get('name')}")
+
+
+@app.command("report")
+def device_report(
+    device_name: Optional[str] = typer.Argument(
+        None, help="Device name (defaults to active device)",
+    ),
+    output: Optional[str] = typer.Option(
+        None, "--output", "-o",
+        help="Path to write HTML file (default: system temp dir)",
+    ),
+    no_open: bool = typer.Option(
+        False, "--no-open",
+        help="Write the file but do not open it in the browser",
+    ),
+):
+    """
+    Generate a self-contained HTML dashboard for a device and open it in your browser.
+
+    Fetches device details, latest status, 30-day battery & temperature telemetry,
+    recent commands, and installed apps — then renders everything into a single HTML file.
+    """
+    import json
+    import os
+    import sys
+    import tempfile
+    import webbrowser
+    from ast import literal_eval
+    from datetime import datetime, timedelta
+
+    import requests
+    from esper.cli.output import console as _console
+    from esper.cli.report_html import generate_html
+    from esper.ext.telemetry_api import get_telemetry_url
+
+    validate_creds()
+    db = DBWrapper(state.creds)
+    config       = db.get_configure()
+    enterprise_id = db.get_enterprise_id()
+    environment  = config.get("environment", "")
+    api_key      = config.get("api_key", "")
+    device_client = APIClient(config).get_device_api_client()
+
+    # ── Resolve device name ────────────────────────────────────────────────
+    if not device_name:
+        dev = db.get_device()
+        if not dev or not dev.get("name"):
+            render("No device specified and no active device set. "
+                   "Pass a device name or run: espercli device set-active --name NAME")
+            raise typer.Exit(1)
+        device_name = dev["name"]
+
+    with _console.status(f"[dim]Fetching data for [bold]{device_name}[/bold]…[/dim]", spinner="dots"):
+
+        # ── Device details ─────────────────────────────────────────────────
+        try:
+            resp = device_client.get_all_devices(enterprise_id, limit=1, offset=0, name=device_name)
+            if not resp.results:
+                render(f"Device not found: {device_name}")
+                raise typer.Exit(1)
+            dev_obj = resp.results[0]
+        except ApiException as e:
+            render(f"ERROR: {parse_error_message(e)}")
+            raise typer.Exit(1)
+
+        device_id    = dev_obj.id
+        alias        = dev_obj.alias_name or dev_obj.device_name
+        hw_name      = dev_obj.device_name
+        api_level    = dev_obj.api_level
+        is_gms       = dev_obj.is_gms
+        dev_state    = DeviceState(dev_obj.status).name
+
+        # ── Latest status ──────────────────────────────────────────────────
+        status_data: dict = {}
+        try:
+            st_resp = device_client.get_device_event(enterprise_id, device_id, latest_event=1)
+            if st_resp.results:
+                raw = literal_eval(st_resp.results[0].data)
+                pm  = raw.get("powerManagementEvent", {})
+                bs  = pm.get("batteryStatus", {})
+                du  = raw.get("dataUsageStats", {})
+                mem = raw.get("memoryEvents", [])
+                net = raw.get("networkEvent", {})
+                wifi = net.get("wifiNetworkInfo", {})
+                status_data = {
+                    "battery_level":       bs.get("batteryLevel"),
+                    "battery_temperature": bs.get("batteryTemperature"),
+                    "data_download":       du.get("totalDataDownload"),
+                    "data_upload":         du.get("totalDataUpload"),
+                    "memory_storage":      mem[1].get("countInMb") if len(mem) > 1 else None,
+                    "memory_ram":          mem[0].get("countInMb") if len(mem) > 0 else None,
+                    "link_speed":          wifi.get("linkSpeed"),
+                    "signal_strength":     wifi.get("signalStrength"),
+                }
+        except Exception:
+            pass  # status is optional; dashboard still renders without it
+
+        # ── Telemetry: battery level (30 days, daily avg) ──────────────────
+        def _fetch_telemetry(category: str, metric: str) -> list:
+            now  = datetime.now()
+            frm  = (now - timedelta(days=30)).strftime("%Y-%m-%dT%H:%M:%S.0000Z")
+            to   = now.strftime("%Y-%m-%dT%H:%M:%S.0000Z")
+            url  = get_telemetry_url(
+                environment, enterprise_id, device_id,
+                category, metric, frm, to, "day", "avg",
+            )
+            try:
+                r = requests.get(url, headers={"Authorization": f"Bearer {api_key}"}, timeout=10)
+                if r.status_code == 200:
+                    pts = r.json().get("data", [])
+                    return [{"x": p["x"][:10], "y": round(p["y"], 1)} for p in pts]
+            except Exception:
+                pass
+            return []
+
+        battery_telemetry = _fetch_telemetry("battery", "level")
+        temp_telemetry    = _fetch_telemetry("battery", "temperature")
+
+        # ── Recent commands (last 10) ──────────────────────────────────────
+        commands: list = []
+        try:
+            cmdv2_client = APIClient(config).get_commandsV2_api_client()
+            cmd_resp = cmdv2_client.list_command_request(enterprise_id, devices=device_id)
+            for req in (cmd_resp.results or [])[:10]:
+                issued_raw = req.issued_by.replace("'", '"')
+                try:
+                    issued_by = json.loads(issued_raw).get("username", issued_raw)
+                except Exception:
+                    issued_by = req.issued_by
+                state_val = None
+                if req.status:
+                    state_val = req.status[0].state
+                created = req.created_on
+                if created:
+                    try:
+                        dt = datetime.fromisoformat(str(created).replace("Z", "+00:00"))
+                        date_str = dt.strftime("%b %d, %H:%M")
+                    except Exception:
+                        date_str = str(created)[:16]
+                else:
+                    date_str = "—"
+                commands.append({
+                    "date":      date_str,
+                    "command":   req.command,
+                    "issued_by": issued_by,
+                    "state":     state_val or "—",
+                })
+        except Exception:
+            pass
+
+        # ── Install count ──────────────────────────────────────────────────
+        installs_count = 0
+        try:
+            inst_client = APIClient(config).get_install_api_client()
+            inst_resp   = inst_client.get_app_installs(enterprise_id, device_id, limit=1)
+            installs_count = inst_resp.count or 0
+        except Exception:
+            pass
+
+    # ── Build data dict ────────────────────────────────────────────────────
+    data = {
+        "name":              alias,
+        "hardware_name":     hw_name,
+        "device_id":         device_id,
+        "state":             dev_state,
+        "api_level":         api_level,
+        "is_gms":            is_gms,
+        "generated_at":      datetime.now().strftime("%B %d, %Y at %H:%M"),
+        "status":            status_data,
+        "battery_telemetry": battery_telemetry,
+        "temp_telemetry":    temp_telemetry,
+        "commands":          commands,
+        "installs_count":    installs_count,
+    }
+
+    # ── Render HTML ────────────────────────────────────────────────────────
+    html = generate_html(data)
+
+    # ── Write file ─────────────────────────────────────────────────────────
+    if output:
+        out_path = os.path.abspath(output)
+    else:
+        tmp_dir  = tempfile.gettempdir()
+        safe_name = alias.replace(" ", "_").replace("/", "_")
+        out_path = os.path.join(tmp_dir, f"esper_report_{safe_name}.html")
+
+    with open(out_path, "w", encoding="utf-8") as fh:
+        fh.write(html)
+
+    render(f"Report written to {out_path}")
+
+    if not no_open:
+        webbrowser.open(f"file://{out_path}")
+        _console.print("[dim]Opening in browser…[/dim]")

--- a/esper/cli/device_command.py
+++ b/esper/cli/device_command.py
@@ -1,0 +1,299 @@
+"""
+Device command controller — replaces esper/controllers/device/command.py.
+`espercli device-command show/install/uninstall/ping/lock/reboot/wipe/clear-app-data`
+"""
+from typing import Optional
+
+import typer
+from esperclient import CommandRequest
+from esperclient.rest import ApiException
+
+from esper.cli.completions import device_name_complete
+from esper.cli.output import render
+from esper.cli.state import state, validate_creds, parse_error_message
+from esper.controllers.enums import DeviceCommandEnum, OutputFormat
+from esper.ext.api_client import APIClient
+from esper.ext.db_wrapper import DBWrapper
+
+app = typer.Typer(help="Fire commands at a device")
+
+
+# ---------------------------------------------------------------------------
+# Shared helpers
+# ---------------------------------------------------------------------------
+
+def _command_basic_response(command, fmt=OutputFormat.TABULATED):
+    valid_keys = ["id", "command", "state"]
+    if fmt == OutputFormat.TABULATED:
+        title, details = "TITLE", "DETAILS"
+        return [{title: k, details: v} for k, v in command.to_dict().items() if k in valid_keys]
+    return {k: v for k, v in command.to_dict().items() if k in valid_keys}
+
+
+def _resolve_device_id(db, enterprise_id, device_name: Optional[str], tag: str) -> str:
+    """Return a device_id for the given name or fall back to the active device."""
+    device_client = APIClient(db.get_configure()).get_device_api_client()
+    if device_name:
+        try:
+            search_response = device_client.get_all_devices(
+                enterprise_id, limit=1, offset=0, name=device_name
+            )
+            if not search_response.results:
+                render(f"Device does not exist with name {device_name}")
+                raise typer.Exit(1)
+            return search_response.results[0].id
+        except ApiException as e:
+            state.log.error(f"[{tag}] Failed to list devices: {e}")
+            render(f"ERROR: {parse_error_message(e)}")
+            raise typer.Exit(1)
+    else:
+        device = db.get_device()
+        if not device or not device.get("id"):
+            render("There is no active device.")
+            raise typer.Exit(1)
+        return device.get("id")
+
+
+# ---------------------------------------------------------------------------
+# Commands
+# ---------------------------------------------------------------------------
+
+@app.command("show")
+def command_show(
+    command_id: str = typer.Argument(..., help="Device command ID"),
+    device: Optional[str] = typer.Option(None, "--device", "-d", help="Device name", shell_complete=device_name_complete),
+    json_output: bool = typer.Option(False, "--json", "-j", help="Render result in JSON format"),
+):
+    """Show command details."""
+    validate_creds()
+    db = DBWrapper(state.creds)
+    command_client = APIClient(db.get_configure()).get_command_api_client()
+    enterprise_id = db.get_enterprise_id()
+
+    device_id = _resolve_device_id(db, enterprise_id, device, "device-command-show")
+
+    try:
+        response = command_client.get_command(command_id, device_id, enterprise_id)
+    except ApiException as e:
+        state.log.error(f"[device-command-show] Failed to show command: {e}")
+        render(f"ERROR: {parse_error_message(e)}")
+        raise typer.Exit(1)
+
+    if not json_output:
+        render(_command_basic_response(response), format=OutputFormat.TABULATED.value, headers="keys", tablefmt="plain")
+    else:
+        render(_command_basic_response(response, OutputFormat.JSON), format=OutputFormat.JSON.value)
+
+
+@app.command("install")
+def command_install(
+    device: Optional[str] = typer.Option(None, "--device", "-d", help="Device name", shell_complete=device_name_complete),
+    version: Optional[str] = typer.Option(None, "--version", "-V", help="Application version ID"),
+    json_output: bool = typer.Option(False, "--json", "-j", help="Render result in JSON format"),
+):
+    """Install an application version on a device."""
+    validate_creds()
+    db = DBWrapper(state.creds)
+    command_client = APIClient(db.get_configure()).get_command_api_client()
+    enterprise_id = db.get_enterprise_id()
+    device_id = _resolve_device_id(db, enterprise_id, device, "device-command-install")
+
+    command_request = CommandRequest(
+        command_args={"app_version": version},
+        command=DeviceCommandEnum.INSTALL.name,
+    )
+    try:
+        response = command_client.run_command(enterprise_id, device_id, command_request)
+    except ApiException as e:
+        state.log.error(f"[device-command-install] Failed to fire install command: {e}")
+        render(f"ERROR: {parse_error_message(e)}")
+        raise typer.Exit(1)
+
+    if not json_output:
+        render(_command_basic_response(response), format=OutputFormat.TABULATED.value, headers="keys", tablefmt="plain")
+    else:
+        render(_command_basic_response(response, OutputFormat.JSON), format=OutputFormat.JSON.value)
+
+
+@app.command("uninstall")
+def command_uninstall(
+    device: Optional[str] = typer.Option(None, "--device", "-d", help="Device name", shell_complete=device_name_complete),
+    version: Optional[str] = typer.Option(None, "--version", "-V", help="Application version ID"),
+    json_output: bool = typer.Option(False, "--json", "-j", help="Render result in JSON format"),
+):
+    """Uninstall an application version from a device."""
+    validate_creds()
+    db = DBWrapper(state.creds)
+    command_client = APIClient(db.get_configure()).get_command_api_client()
+    enterprise_id = db.get_enterprise_id()
+    device_id = _resolve_device_id(db, enterprise_id, device, "device-command-uninstall")
+
+    command_request = CommandRequest(
+        command_args={"app_version": version},
+        command=DeviceCommandEnum.UNINSTALL.name,
+    )
+    try:
+        response = command_client.run_command(enterprise_id, device_id, command_request)
+    except ApiException as e:
+        state.log.error(f"[device-command-uninstall] Failed to fire uninstall command: {e}")
+        render(f"ERROR: {parse_error_message(e)}")
+        raise typer.Exit(1)
+
+    if not json_output:
+        render(_command_basic_response(response), format=OutputFormat.TABULATED.value, headers="keys", tablefmt="plain")
+    else:
+        render(_command_basic_response(response, OutputFormat.JSON), format=OutputFormat.JSON.value)
+
+
+@app.command("ping")
+def command_ping(
+    device: Optional[str] = typer.Option(None, "--device", "-d", help="Device name", shell_complete=device_name_complete),
+    json_output: bool = typer.Option(False, "--json", "-j", help="Render result in JSON format"),
+):
+    """Ping a device (update heartbeat)."""
+    validate_creds()
+    db = DBWrapper(state.creds)
+    command_client = APIClient(db.get_configure()).get_command_api_client()
+    enterprise_id = db.get_enterprise_id()
+    device_id = _resolve_device_id(db, enterprise_id, device, "device-command-ping")
+
+    command_request = CommandRequest(command=DeviceCommandEnum.UPDATE_HEARTBEAT.name)
+    try:
+        response = command_client.run_command(enterprise_id, device_id, command_request)
+    except ApiException as e:
+        state.log.error(f"[device-command-ping] Failed to fire ping command: {e}")
+        render(f"ERROR: {parse_error_message(e)}")
+        raise typer.Exit(1)
+
+    if not json_output:
+        render(_command_basic_response(response), format=OutputFormat.TABULATED.value, headers="keys", tablefmt="plain")
+    else:
+        render(_command_basic_response(response, OutputFormat.JSON), format=OutputFormat.JSON.value)
+
+
+@app.command("lock")
+def command_lock(
+    device: Optional[str] = typer.Option(None, "--device", "-d", help="Device name", shell_complete=device_name_complete),
+    json_output: bool = typer.Option(False, "--json", "-j", help="Render result in JSON format"),
+):
+    """Lock a device."""
+    validate_creds()
+    db = DBWrapper(state.creds)
+    command_client = APIClient(db.get_configure()).get_command_api_client()
+    enterprise_id = db.get_enterprise_id()
+    device_id = _resolve_device_id(db, enterprise_id, device, "device-command-lock")
+
+    command_request = CommandRequest(command=DeviceCommandEnum.LOCK.name)
+    try:
+        response = command_client.run_command(enterprise_id, device_id, command_request)
+    except ApiException as e:
+        state.log.error(f"[device-command-lock] Failed to fire lock command: {e}")
+        render(f"ERROR: {parse_error_message(e)}")
+        raise typer.Exit(1)
+
+    if not json_output:
+        render(_command_basic_response(response), format=OutputFormat.TABULATED.value, headers="keys", tablefmt="plain")
+    else:
+        render(_command_basic_response(response, OutputFormat.JSON), format=OutputFormat.JSON.value)
+
+
+@app.command("reboot")
+def command_reboot(
+    device: Optional[str] = typer.Option(None, "--device", "-d", help="Device name", shell_complete=device_name_complete),
+    json_output: bool = typer.Option(False, "--json", "-j", help="Render result in JSON format"),
+):
+    """Reboot a device."""
+    validate_creds()
+    db = DBWrapper(state.creds)
+    command_client = APIClient(db.get_configure()).get_command_api_client()
+    enterprise_id = db.get_enterprise_id()
+    device_id = _resolve_device_id(db, enterprise_id, device, "device-command-reboot")
+
+    command_request = CommandRequest(command=DeviceCommandEnum.REBOOT.name)
+    try:
+        response = command_client.run_command(enterprise_id, device_id, command_request)
+    except ApiException as e:
+        state.log.error(f"[device-command-reboot] Failed to fire reboot command: {e}")
+        render(f"ERROR: {parse_error_message(e)}")
+        raise typer.Exit(1)
+
+    if not json_output:
+        render(_command_basic_response(response), format=OutputFormat.TABULATED.value, headers="keys", tablefmt="plain")
+    else:
+        render(_command_basic_response(response, OutputFormat.JSON), format=OutputFormat.JSON.value)
+
+
+@app.command("wipe")
+def command_wipe(
+    device: Optional[str] = typer.Option(None, "--device", "-d", help="Device name", shell_complete=device_name_complete),
+    external_storage: bool = typer.Option(
+        False, "--exstorage", "-e", help="Wipe external storage"
+    ),
+    frp: bool = typer.Option(False, "--frp", "-f", help="Factory reset protection"),
+    yes: bool = typer.Option(False, "--yes", "-y", help="Skip confirmation prompt"),
+    json_output: bool = typer.Option(False, "--json", "-j", help="Render result in JSON format"),
+):
+    """Wipe a device (⚠ destructive — requires confirmation)."""
+    target = device or "(active device)"
+    if not yes:
+        typer.confirm(
+            f"⚠  This will WIPE {target}.  All data will be erased.  Continue?",
+            abort=True,
+        )
+    validate_creds()
+    db = DBWrapper(state.creds)
+    command_client = APIClient(db.get_configure()).get_command_api_client()
+    enterprise_id = db.get_enterprise_id()
+    device_id = _resolve_device_id(db, enterprise_id, device, "device-command-wipe")
+
+    command_request = CommandRequest(
+        command_args={"wipe_external_storage": external_storage, "wipe_FRP": frp},
+        command=DeviceCommandEnum.WIPE.name,
+    )
+    try:
+        response = command_client.run_command(enterprise_id, device_id, command_request)
+    except ApiException as e:
+        state.log.error(f"[device-command-wipe] Failed to fire wipe command: {e}")
+        render(f"ERROR: {parse_error_message(e)}")
+        raise typer.Exit(1)
+
+    if not json_output:
+        render(_command_basic_response(response), format=OutputFormat.TABULATED.value, headers="keys", tablefmt="plain")
+    else:
+        render(_command_basic_response(response, OutputFormat.JSON), format=OutputFormat.JSON.value)
+
+
+@app.command("clear-app-data")
+def command_clear_app_data(
+    device: Optional[str] = typer.Option(None, "--device", "-d", help="Device name", shell_complete=device_name_complete),
+    package_name: Optional[str] = typer.Option(
+        None, "--package-name", "-P", help="Application package name"
+    ),
+    json_output: bool = typer.Option(False, "--json", "-j", help="Render result in JSON format"),
+):
+    """Clear application data on a device."""
+    validate_creds()
+    db = DBWrapper(state.creds)
+    command_client = APIClient(db.get_configure()).get_command_api_client()
+    enterprise_id = db.get_enterprise_id()
+    device_id = _resolve_device_id(db, enterprise_id, device, "device-command-clear-app-data")
+
+    if not package_name:
+        render("Package name is empty")
+        raise typer.Exit(1)
+
+    command_request = CommandRequest(
+        command_args={"package_name": package_name},
+        command=DeviceCommandEnum.CLEAR_APP_DATA.name,
+    )
+    try:
+        response = command_client.run_command(enterprise_id, device_id, command_request)
+    except ApiException as e:
+        state.log.error(f"[device-command-clear-app-data] Failed to fire CLEAR_APP_DATA command: {e}")
+        render(f"ERROR: {parse_error_message(e)}")
+        raise typer.Exit(1)
+
+    if not json_output:
+        render(_command_basic_response(response), format=OutputFormat.TABULATED.value, headers="keys", tablefmt="plain")
+    else:
+        render(_command_basic_response(response, OutputFormat.JSON), format=OutputFormat.JSON.value)

--- a/esper/cli/enterprise.py
+++ b/esper/cli/enterprise.py
@@ -1,0 +1,128 @@
+"""
+Enterprise commands — replaces esper/controllers/enterprise/enterprise.py.
+`espercli enterprise show/update`
+"""
+from typing import Optional
+
+import typer
+from esperclient import EnterpriseUpdateV1
+from esperclient.rest import ApiException
+
+from esper.cli.output import render
+from esper.cli.state import state, validate_creds, parse_error_message
+from esper.controllers.enums import OutputFormat
+from esper.ext.api_client import APIClient
+from esper.ext.db_wrapper import DBWrapper
+
+app = typer.Typer(help="Enterprise commands")
+
+
+# ---------------------------------------------------------------------------
+# Shared helpers
+# ---------------------------------------------------------------------------
+
+def _enterprise_basic_response(enterprise, fmt=OutputFormat.TABULATED):
+    registered_name = getattr(enterprise, "registered_name", None)
+    address = getattr(enterprise, "registered_address", None)
+    location = getattr(enterprise, "location", None)
+    zipcode = getattr(enterprise, "zipcode", None)
+    email = getattr(enterprise, "contact_email", None)
+    contact_person = getattr(enterprise, "contact_person", None)
+    contact_number = getattr(enterprise, "contact_number", None)
+
+    if fmt == OutputFormat.TABULATED:
+        title, details = "TITLE", "DETAILS"
+        return [
+            {title: "Enterprise Id", details: enterprise.id},
+            {title: "Name", details: enterprise.name},
+            {title: "Registered Name", details: registered_name},
+            {title: "Address", details: address},
+            {title: "Location", details: location},
+            {title: "Zip Code", details: zipcode},
+            {title: "Email", details: email},
+            {title: "Contact Person", details: contact_person},
+            {title: "Contact Number", details: contact_number},
+        ]
+    return {
+        "Enterprise Id": enterprise.id, "Name": enterprise.name,
+        "Registered Name": registered_name, "Address": address,
+        "Location": location, "Zip Code": zipcode, "Email": email,
+        "Contact Person": contact_person, "Contact Number": contact_number,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Commands
+# ---------------------------------------------------------------------------
+
+@app.command("show")
+def enterprise_show(
+    json_output: bool = typer.Option(False, "--json", "-j", help="Render result in JSON format"),
+):
+    """Show enterprise details."""
+    validate_creds()
+    db = DBWrapper(state.creds)
+    enterprise_client = APIClient(db.get_configure()).get_enterprise_api_client()
+    enterprise_id = db.get_enterprise_id()
+
+    try:
+        response = enterprise_client.get_enterprise(enterprise_id)
+    except ApiException as e:
+        state.log.error(f"[enterprise-show] Failed to show enterprise: {e}")
+        render(f"ERROR: {parse_error_message(e)}")
+        raise typer.Exit(1)
+
+    if not json_output:
+        render(_enterprise_basic_response(response), format=OutputFormat.TABULATED.value, headers="keys", tablefmt="plain")
+    else:
+        render(_enterprise_basic_response(response, OutputFormat.JSON), format=OutputFormat.JSON.value)
+
+
+@app.command("update")
+def enterprise_update(
+    name: Optional[str] = typer.Option(None, "--name", "-n", help="Enterprise name"),
+    display_name: Optional[str] = typer.Option(None, "--dispname", "-dn", help="Display name"),
+    registered_name: Optional[str] = typer.Option(None, "--regname", "-rn", help="Registered name"),
+    address: Optional[str] = typer.Option(None, "--address", "-a", help="Enterprise address"),
+    location: Optional[str] = typer.Option(None, "--location", "-l", help="Enterprise location"),
+    zipcode: Optional[str] = typer.Option(None, "--zipcode", "-z", help="Zip code"),
+    email: Optional[str] = typer.Option(None, "--email", "-e", help="Contact email"),
+    contact_person: Optional[str] = typer.Option(None, "--person", "-p", help="Contact person"),
+    contact_number: Optional[str] = typer.Option(None, "--number", "-cn", help="Contact number"),
+    json_output: bool = typer.Option(False, "--json", "-j", help="Render result in JSON format"),
+):
+    """Update enterprise details."""
+    validate_creds()
+    db = DBWrapper(state.creds)
+    enterprise_client = APIClient(db.get_configure()).get_enterprise_api_client()
+    enterprise_id = db.get_enterprise_id()
+
+    update_dict = {}
+    if name:
+        update_dict["name"] = name
+    if registered_name:
+        update_dict["registered_name"] = registered_name
+    if address:
+        update_dict["registered_address"] = address
+    if location:
+        update_dict["location"] = location
+    if zipcode:
+        update_dict["zipcode"] = zipcode
+    if email:
+        update_dict["contact_email"] = email
+    if contact_person:
+        update_dict["contact_person"] = contact_person
+    if contact_number:
+        update_dict["contact_number"] = contact_number
+
+    try:
+        response = enterprise_client.partial_update_enterprise(enterprise_id, update_dict)
+    except ApiException as e:
+        state.log.error(f"[enterprise-update] Failed to update enterprise: {e}")
+        render(f"ERROR: {parse_error_message(e)}")
+        raise typer.Exit(1)
+
+    if not json_output:
+        render(_enterprise_basic_response(response), format=OutputFormat.TABULATED.value, headers="keys", tablefmt="plain")
+    else:
+        render(_enterprise_basic_response(response, OutputFormat.JSON), format=OutputFormat.JSON.value)

--- a/esper/cli/execute.py
+++ b/esper/cli/execute.py
@@ -1,0 +1,225 @@
+"""
+Pipeline Execute commands — nested under `pipeline`.
+`espercli pipeline execute start/stop/continue/terminate/show`
+"""
+from typing import Optional
+
+import typer
+
+from esper.cli.output import render
+from esper.cli.state import state, validate_creds
+from esper.controllers.enums import OutputFormat
+from esper.ext.db_wrapper import DBWrapper
+from esper.ext.pipeline_api import (
+    execute_pipeline, list_execute_pipeline, get_pipeline_execute_url,
+    APIException, render_single_dict,
+)
+
+app = typer.Typer(help="Pipeline Execute commands")
+
+
+# ---------------------------------------------------------------------------
+# Shared helpers
+# ---------------------------------------------------------------------------
+
+def _handle_execute_error(response, tag: str):
+    state.log.debug(f"[{tag}] Response not OK. Status: {response.status_code}")
+    if response.status_code == 400:
+        if isinstance(response.json(), dict):
+            errors = response.json().get("meta", {}).get("non_field_errors")
+            if errors:
+                state.log.error(f"Validation Error: {errors}")
+            field_errors = response.json().get("errors")
+            if field_errors:
+                msg = response.json().get("message", "")
+                if "The fields pipeline, ordering must make a unique set." in msg:
+                    state.log.error("Operation with same `name` already created for this Stage!")
+                else:
+                    state.log.error(f"Validation Error: {field_errors}")
+        else:
+            state.log.error(f"Validation Errors -> {response.json()}")
+    elif response.status_code == 404:
+        state.log.error("Pipeline URL not found!")
+    elif response.status_code == 500:
+        state.log.error(f"Internal Server Error! {response.json()}")
+
+
+# ---------------------------------------------------------------------------
+# Commands
+# ---------------------------------------------------------------------------
+
+@app.command("start")
+def execute_start(
+    pipeline_id: Optional[str] = typer.Option(None, "--pipeline-id", "-p", help="Pipeline ID"),
+):
+    """Start a Pipeline Execution."""
+    validate_creds()
+    db = DBWrapper(state.creds)
+    environment = db.get_configure().get("environment")
+    enterprise_id = db.get_enterprise_id()
+    api_key = db.get_configure().get("api_key")
+
+    if not pipeline_id:
+        pipeline_id = typer.prompt("Enter the Pipeline ID")
+
+    url = get_pipeline_execute_url(environment, enterprise_id, pipeline_id)
+    try:
+        response = execute_pipeline(url, api_key)
+    except APIException:
+        render("ERROR in connecting to Environment!")
+        raise typer.Exit(1)
+
+    if not response.ok:
+        _handle_execute_error(response, "execute-start")
+        raise typer.Exit(1)
+
+    data = render_single_dict(response.json())
+    render("Pipeline execution started! Details:")
+    render(data, format=OutputFormat.TABULATED.value, headers="keys", tablefmt="plain")
+
+
+@app.command("stop")
+def execute_stop(
+    pipeline_id: Optional[str] = typer.Option(None, "--pipeline-id", "-p", help="Pipeline ID"),
+    execution_id: Optional[str] = typer.Option(None, "--execution-id", "-e", help="Execution ID"),
+    reason: Optional[str] = typer.Option(None, "--reason", "-r", help="Reason for stopping"),
+):
+    """Stop a Pipeline Execution."""
+    validate_creds()
+    db = DBWrapper(state.creds)
+    environment = db.get_configure().get("environment")
+    enterprise_id = db.get_enterprise_id()
+    api_key = db.get_configure().get("api_key")
+
+    if not pipeline_id:
+        pipeline_id = typer.prompt("Enter the Pipeline ID")
+    if not execution_id:
+        execution_id = typer.prompt("Enter the Execution ID")
+    if not reason:
+        reason = typer.prompt("Why do you want to stop this Execution?")
+
+    url = get_pipeline_execute_url(environment, enterprise_id, pipeline_id, execution_id, "stop")
+    try:
+        response = execute_pipeline(url, api_key, {"reason": reason})
+    except APIException:
+        render("ERROR in connecting to Environment!")
+        raise typer.Exit(1)
+
+    if not response.ok:
+        _handle_execute_error(response, "execute-stop")
+        raise typer.Exit(1)
+
+    data = render_single_dict(response.json())
+    render("Pipeline execution stopped! Details:")
+    render(data, format=OutputFormat.TABULATED.value, headers="keys", tablefmt="plain")
+
+
+@app.command("continue")
+def execute_continue(
+    pipeline_id: Optional[str] = typer.Option(None, "--pipeline-id", "-p", help="Pipeline ID"),
+    execution_id: Optional[str] = typer.Option(None, "--execution-id", "-e", help="Execution ID"),
+):
+    """Continue a paused Pipeline Execution."""
+    validate_creds()
+    db = DBWrapper(state.creds)
+    environment = db.get_configure().get("environment")
+    enterprise_id = db.get_enterprise_id()
+    api_key = db.get_configure().get("api_key")
+
+    if not pipeline_id:
+        pipeline_id = typer.prompt("Enter the Pipeline ID")
+    if not execution_id:
+        execution_id = typer.prompt("Enter the Execution ID")
+
+    url = get_pipeline_execute_url(environment, enterprise_id, pipeline_id, execution_id, "continue")
+    try:
+        response = execute_pipeline(url, api_key)
+    except APIException:
+        render("ERROR in connecting to Environment!")
+        raise typer.Exit(1)
+
+    if not response.ok:
+        _handle_execute_error(response, "execute-continue")
+        raise typer.Exit(1)
+
+    data = render_single_dict(response.json())
+    render("Pipeline execution continuing! Details:")
+    render(data, format=OutputFormat.TABULATED.value, headers="keys", tablefmt="plain")
+
+
+@app.command("terminate")
+def execute_terminate(
+    pipeline_id: Optional[str] = typer.Option(None, "--pipeline-id", "-p", help="Pipeline ID"),
+    execution_id: Optional[str] = typer.Option(None, "--execution-id", "-e", help="Execution ID"),
+    reason: Optional[str] = typer.Option(None, "--reason", "-r", help="Reason for termination"),
+):
+    """Terminate a Pipeline Execution."""
+    validate_creds()
+    db = DBWrapper(state.creds)
+    environment = db.get_configure().get("environment")
+    enterprise_id = db.get_enterprise_id()
+    api_key = db.get_configure().get("api_key")
+
+    if not pipeline_id:
+        pipeline_id = typer.prompt("Enter the Pipeline ID")
+    if not execution_id:
+        execution_id = typer.prompt("Enter the Execution ID")
+    if not reason:
+        reason = typer.prompt("Why do you want to terminate this Execution?")
+
+    url = get_pipeline_execute_url(environment, enterprise_id, pipeline_id, execution_id, "terminate")
+    try:
+        response = execute_pipeline(url, api_key, {"reason": reason})
+    except APIException:
+        render("ERROR in connecting to Environment!")
+        raise typer.Exit(1)
+
+    if not response.ok:
+        _handle_execute_error(response, "execute-terminate")
+        raise typer.Exit(1)
+
+    data = render_single_dict(response.json())
+    render("Pipeline execution Terminated! Details:")
+    render(data, format=OutputFormat.TABULATED.value, headers="keys", tablefmt="plain")
+
+
+@app.command("show")
+def execute_show(
+    pipeline_id: Optional[str] = typer.Option(None, "--pipeline-id", "-p", help="Pipeline ID"),
+):
+    """List all Executions for a Pipeline."""
+    validate_creds()
+    db = DBWrapper(state.creds)
+    environment = db.get_configure().get("environment")
+    enterprise_id = db.get_enterprise_id()
+    api_key = db.get_configure().get("api_key")
+
+    if not pipeline_id:
+        pipeline_id = typer.prompt("Enter the Pipeline ID")
+
+    url = get_pipeline_execute_url(environment, enterprise_id, pipeline_id)
+    try:
+        response = list_execute_pipeline(url, api_key)
+    except APIException:
+        render("ERROR in connecting to Environment!")
+        raise typer.Exit(1)
+
+    if not response.ok:
+        _handle_execute_error(response, "execute-show")
+        raise typer.Exit(1)
+
+    data = response.json().get("results") or []
+    render_data = [
+        {
+            "ID": ex.get("id"),
+            "NAME": ex.get("name"),
+            "DESCRIPTION": ex.get("description"),
+            "STATE": ex.get("state"),
+            "STATUS": ex.get("status"),
+            "REASON": ex.get("reason"),
+        }
+        for ex in data
+    ]
+
+    render("Listing Executions for the Pipeline! Details:")
+    render(render_data, format=OutputFormat.TABULATED.value, headers="keys", tablefmt="plain")

--- a/esper/cli/fleet.py
+++ b/esper/cli/fleet.py
@@ -1,0 +1,102 @@
+# Fleet overview commands — merges v1 and v2 status-metrics endpoints.
+from typing import Optional
+
+import typer
+from rich.console import Console
+from rich.panel import Panel
+from rich.table import Table, box
+
+from esper.cli.output import render
+from esper.cli.state import state, validate_creds
+from esper.controllers.enums import OutputFormat
+from esper.ext.api_rest import api_get
+from esper.ext.db_wrapper import DBWrapper
+
+app = typer.Typer(help="Fleet overview commands")
+
+console = Console()
+
+
+@app.command("status")
+def fleet_status(
+    as_json: bool = typer.Option(False, "--json", "-j", help="Output as JSON"),
+) -> None:
+    """Show fleet health, risk, and last-seen breakdown."""
+    validate_creds()
+    db = DBWrapper(state.creds)
+    cfg = db.get_configure()
+    environment = cfg.get("environment")
+    api_key = cfg.get("api_key")
+    eid = db.get_enterprise_id()
+
+    try:
+        v1 = api_get(environment, api_key, f"/v1/enterprise/{eid}/report/status-metrics/")
+        v2 = api_get(environment, api_key, f"/v2/enterprise/{eid}/report/status-metrics")
+    except Exception as e:
+        render(f"ERROR: {e}")
+        raise typer.Exit(1)
+
+    last_seen = v2.get("last_seen", {})
+
+    if as_json:
+        render({
+            "health": {
+                "active": v1.get("active"),
+                "inactive": v1.get("in_active"),
+                "total": v1.get("active", 0) + v1.get("in_active", 0),
+                "low_battery": v1.get("low_battery"),
+                "under_provisioning": v1.get("under_provisioning"),
+            },
+            "risk": {
+                "low_risk": v1.get("low_risk"),
+                "medium_risk": v1.get("medium_risk"),
+                "high_risk": v1.get("high_risk"),
+                "secure": v1.get("secure"),
+                "total_devices_under_risk": v1.get("total_devices_under_risk"),
+            },
+            "last_seen": {
+                "last_24h": last_seen.get("first_period"),
+                "last_1_7d": last_seen.get("second_period"),
+                "last_7_30d": last_seen.get("third_period"),
+            },
+        }, format=OutputFormat.JSON.value)
+        return
+
+    # Device health table
+    health_tbl = Table(box=box.SIMPLE_HEAD, show_header=True, header_style="bold cyan",
+                       show_edge=False, pad_edge=False)
+    health_tbl.add_column("Metric", style="bold")
+    health_tbl.add_column("Count", justify="right")
+
+    total = v1.get("active", 0) + v1.get("in_active", 0)
+    health_tbl.add_row("Active",             str(v1.get("active", 0)))
+    health_tbl.add_row("Inactive",           str(v1.get("in_active", 0)))
+    health_tbl.add_row("Total",              str(total))
+    health_tbl.add_row("Low battery",        str(v1.get("low_battery", 0)))
+    health_tbl.add_row("Under provisioning", str(v1.get("under_provisioning", 0)))
+
+    # Risk table
+    risk_tbl = Table(box=box.SIMPLE_HEAD, show_header=True, header_style="bold cyan",
+                     show_edge=False, pad_edge=False)
+    risk_tbl.add_column("Metric", style="bold")
+    risk_tbl.add_column("Count", justify="right")
+
+    risk_tbl.add_row("Low risk",               str(v1.get("low_risk", 0)))
+    risk_tbl.add_row("Medium risk",            str(v1.get("medium_risk", 0)))
+    risk_tbl.add_row("High risk",              str(v1.get("high_risk", 0)))
+    risk_tbl.add_row("Secure",                 str(v1.get("secure", 0)))
+    risk_tbl.add_row("Total devices at risk",  str(v1.get("total_devices_under_risk", 0)))
+
+    # Last seen table
+    seen_tbl = Table(box=box.SIMPLE_HEAD, show_header=True, header_style="bold cyan",
+                     show_edge=False, pad_edge=False)
+    seen_tbl.add_column("Window", style="bold")
+    seen_tbl.add_column("Devices", justify="right")
+
+    seen_tbl.add_row("Last 24 hours",  str(last_seen.get("first_period", 0)))
+    seen_tbl.add_row("1 – 7 days ago", str(last_seen.get("second_period", 0)))
+    seen_tbl.add_row("7 – 30 days ago", str(last_seen.get("third_period", 0)))
+
+    console.print(Panel(health_tbl, title="[bold]Device Health[/bold]", border_style="blue", expand=False))
+    console.print(Panel(risk_tbl,   title="[bold]Risk[/bold]",           border_style="yellow", expand=False))
+    console.print(Panel(seen_tbl,   title="[bold]Last Seen[/bold]",      border_style="cyan", expand=False))

--- a/esper/cli/group.py
+++ b/esper/cli/group.py
@@ -1,0 +1,616 @@
+"""
+Group commands — replaces esper/controllers/enterprise/group.py.
+`espercli group list/show/set-active/unset-active/create/update/delete/add/remove/devices/move`
+"""
+from typing import Optional
+
+import typer
+from esperclient import DeviceGroup, DeviceGroupUpdate, DeviceGroupPartialUpdate
+from esperclient.rest import ApiException
+
+from esper.cli.completions import device_state_complete, group_name_complete
+from esper.cli.output import render
+from esper.cli.state import state, validate_creds, parse_error_message
+from esper.controllers.enums import DeviceState, OutputFormat
+from esper.ext.api_client import APIClient
+from esper.ext.db_wrapper import DBWrapper
+
+app = typer.Typer(help="Device group commands")
+
+
+# ---------------------------------------------------------------------------
+# Shared helpers
+# ---------------------------------------------------------------------------
+
+def _group_basic_response(group, fmt=OutputFormat.TABULATED):
+    parent = group.parent.split("/")[-2] if group.parent else group.parent
+    if fmt == OutputFormat.TABULATED:
+        title, details = "TITLE", "DETAILS"
+        return [
+            {title: "id", details: group.id},
+            {title: "name", details: group.name},
+            {title: "parent_id", details: parent},
+            {title: "device_count", details: group.device_count},
+            {title: "path", details: group.path},
+            {title: "children_count", details: group.children_count},
+        ]
+    return {
+        "id": group.id, "name": group.name, "parent": parent,
+        "device_count": group.device_count, "path": group.path,
+        "children_count": group.children_count,
+    }
+
+
+def _resolve_group_by_name_or_id(
+    group_client, enterprise_id,
+    group_name: Optional[str], group_id: Optional[str], tag: str
+):
+    """Return (group_id, resolved_group_object) by ID or name."""
+    if group_id:
+        try:
+            response = group_client.get_group_by_id(group_id, enterprise_id)
+            if group_name and group_name != response.name:
+                render(f"Group does not exist with id {group_id} and name {group_name}")
+                raise typer.Exit(1)
+            return group_id, response
+        except ApiException as e:
+            state.log.error(f"[{tag}] Group does not exist with id {group_id}: {e}")
+            render(f"ERROR: {parse_error_message(e)}")
+            raise typer.Exit(1)
+    elif group_name:
+        try:
+            search_response = group_client.get_all_groups(
+                enterprise_id, limit=1, offset=0, name=group_name
+            )
+            for g in search_response.results:
+                if g.name == group_name:
+                    return g.id, g
+            render(f"Group does not exist with name {group_name}")
+            raise typer.Exit(1)
+        except ApiException as e:
+            state.log.error(f"[{tag}] Failed to list groups: {e}")
+            render(f"ERROR: {parse_error_message(e)}")
+            raise typer.Exit(1)
+    else:
+        return None, None
+
+
+def _get_group_device_ids(device_client, enterprise_id, group_id) -> list:
+    """Paginate through all devices in a group and return their IDs."""
+    device_ids = []
+    counter = 0
+    limit = 100
+    try:
+        while True:
+            offset = limit * counter
+            response = device_client.get_all_devices(
+                enterprise_id, group=group_id, limit=limit, offset=offset
+            )
+            if not response.results:
+                break
+            device_ids.extend([d.id for d in response.results])
+            counter += 1
+    except ApiException as e:
+        state.log.error(f"[_get_group_device_ids] Failed to list devices: {e}")
+        render(f"ERROR: {parse_error_message(e)}")
+        raise typer.Exit(1)
+    return device_ids
+
+
+# ---------------------------------------------------------------------------
+# Commands
+# ---------------------------------------------------------------------------
+
+@app.command("list")
+def group_list(
+    name: Optional[str] = typer.Option(None, "--name", "-n", help="Filter groups by name"),
+    limit: int = typer.Option(20, "--limit", "-l", help="Results per page"),
+    offset: int = typer.Option(0, "--offset", "-i", help="Initial index"),
+    all_results: bool = typer.Option(
+        False, "--all", "-A",
+        help="Fetch ALL groups, auto-paginating (ignores --limit / --offset).",
+    ),
+    json_output: bool = typer.Option(False, "--json", "-j", help="Render result in JSON format"),
+):
+    """List device groups."""
+    validate_creds()
+    db = DBWrapper(state.creds)
+    group_client = APIClient(db.get_configure()).get_group_api_client()
+    enterprise_id = db.get_enterprise_id()
+
+    kwargs = {}
+    if name:
+        kwargs["name"] = name
+
+    try:
+        if all_results:
+            from esper.cli.output import console as _console
+            results = []
+            page_size, cur_offset = 100, 0
+            with _console.status("[dim]Fetching all groups…[/dim]", spinner="dots"):
+                while True:
+                    page = group_client.get_all_groups(
+                        enterprise_id, limit=page_size, offset=cur_offset, **kwargs
+                    )
+                    results.extend(page.results)
+                    if len(results) >= page.count or not page.results:
+                        break
+                    cur_offset += page_size
+
+            class _FR:
+                def __init__(self, r):
+                    self.results = r
+                    self.count = len(r)
+            response = _FR(results)
+        else:
+            response = group_client.get_all_groups(enterprise_id, limit=limit, offset=offset, **kwargs)
+    except ApiException as e:
+        state.log.error(f"[group-list] Failed to list groups: {e}")
+        render(f"ERROR: {parse_error_message(e)}")
+        raise typer.Exit(1)
+
+    label = {"id": "ID", "name": "NAME", "parent_id": "PARENT ID", "device_count": "DEVICE COUNT"}
+    groups = []
+    for g in response.results:
+        parent = g.parent.split("/")[-2] if g.parent else g.parent
+        groups.append({
+            label["id"]: g.id, label["name"]: g.name,
+            label["device_count"]: g.device_count or 0, label["parent_id"]: parent,
+        })
+
+    render(f"Number of Groups: {response.count}")
+    if not json_output:
+        render(groups, format=OutputFormat.TABULATED.value, headers="keys", tablefmt="plain")
+    else:
+        render(groups, format=OutputFormat.JSON.value)
+
+
+@app.command("show")
+def group_show(
+    group_name: str = typer.Argument(..., help="Group name"),
+    group_id: Optional[str] = typer.Option(None, "--groupid", "-id", help="Group ID"),
+    active: bool = typer.Option(
+        False, "--active", "-a", help="Set as the active group"
+    ),
+    json_output: bool = typer.Option(False, "--json", "-j", help="Render result in JSON format"),
+):
+    """Show group details (and optionally set as active)."""
+    validate_creds()
+    db = DBWrapper(state.creds)
+    group_client = APIClient(db.get_configure()).get_group_api_client()
+    enterprise_id = db.get_enterprise_id()
+
+    gid, response = _resolve_group_by_name_or_id(
+        group_client, enterprise_id, group_name, group_id, "group-show"
+    )
+    if response is None:
+        render(f"Group does not exist with name {group_name}")
+        raise typer.Exit(1)
+
+    if active:
+        db.set_group({"id": response.id, "name": response.name})
+
+    if not json_output:
+        render(_group_basic_response(response), format=OutputFormat.TABULATED.value, headers="keys", tablefmt="plain")
+    else:
+        render(_group_basic_response(response, OutputFormat.JSON), format=OutputFormat.JSON.value)
+
+
+@app.command("set-active")
+def group_set_active(
+    name: Optional[str] = typer.Option(None, "--name", "-n", help="Group name"),
+    group_id: Optional[str] = typer.Option(None, "--groupid", "-id", help="Group ID"),
+    json_output: bool = typer.Option(False, "--json", "-j", help="Render result in JSON format"),
+):
+    """Set or show the active group."""
+    validate_creds()
+    db = DBWrapper(state.creds)
+    group_client = APIClient(db.get_configure()).get_group_api_client()
+    enterprise_id = db.get_enterprise_id()
+
+    if group_id or name:
+        gid, response = _resolve_group_by_name_or_id(
+            group_client, enterprise_id, name, group_id, "group-active"
+        )
+        db.set_group({"id": response.id, "name": response.name})
+    else:
+        group = db.get_group()
+        if group is None or group.get("name") is None:
+            render("There is no active group.")
+            raise typer.Exit(1)
+        try:
+            response = group_client.get_group_by_id(group.get("id"), enterprise_id)
+        except ApiException as e:
+            state.log.error(f"[group-active] Failed to show active group: {e}")
+            render(f"ERROR: {parse_error_message(e)}")
+            raise typer.Exit(1)
+
+    if not json_output:
+        render(_group_basic_response(response), format=OutputFormat.TABULATED.value, headers="keys", tablefmt="plain")
+    else:
+        render(_group_basic_response(response, OutputFormat.JSON), format=OutputFormat.JSON.value)
+
+
+@app.command("unset-active")
+def group_unset_active():
+    """Unset the current active group."""
+    validate_creds()
+    db = DBWrapper(state.creds)
+
+    group = db.get_group()
+    if group is None or group.get("name") is None:
+        render("There is no active group.")
+        raise typer.Exit(1)
+
+    db.unset_group()
+    render(
+        f"Unset the active group with id: {group.get('id')} and name: {group.get('name')}"
+    )
+
+
+@app.command("create")
+def group_create(
+    name: Optional[str] = typer.Option(None, "--name", "-n", help="Group name"),
+    parent: Optional[str] = typer.Option(None, "--parentid", "-pid", help="Parent group ID"),
+    json_output: bool = typer.Option(False, "--json", "-j", help="Render result in JSON format"),
+):
+    """Create a group."""
+    validate_creds()
+    db = DBWrapper(state.creds)
+    group_client = APIClient(db.get_configure()).get_group_api_client()
+    enterprise_id = db.get_enterprise_id()
+
+    if not name:
+        render("name cannot be empty.")
+        raise typer.Exit(1)
+
+    data = DeviceGroup(name=name, parent=parent) if parent else DeviceGroup(name=name)
+
+    try:
+        response = group_client.create_group(enterprise_id, data)
+    except ApiException as e:
+        state.log.error(f"[group-create] Failed to create group: {e}")
+        render(f"ERROR: {parse_error_message(e)}")
+        raise typer.Exit(1)
+
+    if not json_output:
+        render(_group_basic_response(response), format=OutputFormat.TABULATED.value, headers="keys", tablefmt="plain")
+    else:
+        render(_group_basic_response(response, OutputFormat.JSON), format=OutputFormat.JSON.value)
+
+
+@app.command("update")
+def group_update(
+    name: str = typer.Argument(..., help="Group current name"),
+    group_id: Optional[str] = typer.Option(None, "--groupid", "-id", help="Group ID"),
+    new_name: Optional[str] = typer.Option(None, "--name", "-n", help="New group name"),
+    json_output: bool = typer.Option(False, "--json", "-j", help="Render result in JSON format"),
+):
+    """Update a group's name."""
+    validate_creds()
+    db = DBWrapper(state.creds)
+    group_client = APIClient(db.get_configure()).get_group_api_client()
+    enterprise_id = db.get_enterprise_id()
+
+    gid, _ = _resolve_group_by_name_or_id(group_client, enterprise_id, name, group_id, "group-update")
+
+    if not new_name:
+        render("new name cannot be empty.")
+        raise typer.Exit(1)
+
+    data = DeviceGroupPartialUpdate()
+    data.name = new_name
+
+    try:
+        response = group_client.partial_update_group(gid, enterprise_id, data)
+    except ApiException as e:
+        state.log.error(f"[group-update] Failed to update group: {e}")
+        render(f"ERROR: {parse_error_message(e)}")
+        raise typer.Exit(1)
+
+    if not json_output:
+        render(_group_basic_response(response), format=OutputFormat.TABULATED.value, headers="keys", tablefmt="plain")
+    else:
+        render(_group_basic_response(response, OutputFormat.JSON), format=OutputFormat.JSON.value)
+
+
+@app.command("delete")
+def group_delete(
+    name: str = typer.Argument(..., help="Group name"),
+    group_id: Optional[str] = typer.Option(None, "--groupid", "-id", help="Group ID"),
+    yes: bool = typer.Option(False, "--yes", "-y", help="Skip confirmation prompt"),
+):
+    """Delete a group."""
+    if not yes:
+        typer.confirm(f"Delete group '{name}'? This cannot be undone.", abort=True)
+    validate_creds()
+    db = DBWrapper(state.creds)
+    group_client = APIClient(db.get_configure()).get_group_api_client()
+    enterprise_id = db.get_enterprise_id()
+
+    gid, _ = _resolve_group_by_name_or_id(group_client, enterprise_id, name, group_id, "group-delete")
+
+    try:
+        group_client.delete_group(gid, enterprise_id)
+        render(f"Group with name {name} deleted successfully")
+        group = db.get_group()
+        if group and group.get("id") == gid:
+            db.unset_group()
+    except ApiException as e:
+        state.log.error(f"[group-delete] Failed to delete group: {e}")
+        render(f"ERROR: {parse_error_message(e)}")
+        raise typer.Exit(1)
+
+
+@app.command("add")
+def group_add(
+    group: Optional[str] = typer.Option(None, "--group", "-g", help="Group name", shell_complete=group_name_complete),
+    group_id: Optional[str] = typer.Option(None, "--groupid", "-id", help="Group ID"),
+    devices: Optional[str] = typer.Option(
+        None, "--devices", "-d",
+        help='Device names (space-separated, e.g. "dev1 dev2 dev3")'
+    ),
+    json_output: bool = typer.Option(False, "--json", "-j", help="Render result in JSON format"),
+):
+    """Add devices to a group."""
+    validate_creds()
+    db = DBWrapper(state.creds)
+    group_client = APIClient(db.get_configure()).get_group_api_client()
+    device_client = APIClient(db.get_configure()).get_device_api_client()
+    enterprise_id = db.get_enterprise_id()
+
+    if group or group_id:
+        gid, _ = _resolve_group_by_name_or_id(
+            group_client, enterprise_id, group, group_id, "group-add"
+        )
+    else:
+        active = db.get_group()
+        if active is None or active.get("name") is None:
+            render("There is no active group.")
+            raise typer.Exit(1)
+        gid = active.get("id")
+
+    device_names = devices.split() if devices else []
+    if not device_names:
+        render("devices cannot be empty.")
+        raise typer.Exit(1)
+    if len(device_names) > 1000:
+        render("Cannot add more than 1000 devices at a time.")
+        raise typer.Exit(1)
+
+    request_device_ids = []
+    for device_name in device_names:
+        try:
+            search_response = device_client.get_all_devices(
+                enterprise_id, limit=1, offset=0, name=device_name
+            )
+            if not search_response.results:
+                render(f"Device does not exist with name {device_name}")
+                raise typer.Exit(1)
+            request_device_ids.append(search_response.results[0].id)
+        except ApiException as e:
+            state.log.error(f"[group-add] Failed to list devices: {e}")
+            render(f"ERROR: {parse_error_message(e)}")
+            raise typer.Exit(1)
+
+    existing_ids = _get_group_device_ids(device_client, enterprise_id, gid)
+    existing_ids.extend(request_device_ids)
+
+    data = DeviceGroupPartialUpdate()
+    data.device_ids = existing_ids
+
+    try:
+        response = group_client.partial_update_group(gid, enterprise_id, data, action="add")
+    except ApiException as e:
+        state.log.error(f"[group-add] Failed to add devices to group: {e}")
+        render(f"ERROR: {parse_error_message(e)}")
+        raise typer.Exit(1)
+
+    if not json_output:
+        render(_group_basic_response(response), format=OutputFormat.TABULATED.value, headers="keys", tablefmt="plain")
+    else:
+        render(_group_basic_response(response, OutputFormat.JSON), format=OutputFormat.JSON.value)
+
+
+@app.command("remove")
+def group_remove(
+    group: Optional[str] = typer.Option(None, "--group", "-g", help="Group name", shell_complete=group_name_complete),
+    group_id: Optional[str] = typer.Option(None, "--groupid", "-id", help="Group ID"),
+    devices: Optional[str] = typer.Option(
+        None, "--devices", "-d",
+        help='Device names (space-separated, e.g. "dev1 dev2 dev3")'
+    ),
+    json_output: bool = typer.Option(False, "--json", "-j", help="Render result in JSON format"),
+):
+    """Remove devices from a group."""
+    validate_creds()
+    db = DBWrapper(state.creds)
+    group_client = APIClient(db.get_configure()).get_group_api_client()
+    device_client = APIClient(db.get_configure()).get_device_api_client()
+    enterprise_id = db.get_enterprise_id()
+
+    if group or group_id:
+        gid, _ = _resolve_group_by_name_or_id(
+            group_client, enterprise_id, group, group_id, "group-remove"
+        )
+    else:
+        active = db.get_group()
+        if active is None or active.get("name") is None:
+            render("There is no active group.")
+            raise typer.Exit(1)
+        gid = active.get("id")
+
+    device_names = devices.split() if devices else []
+    if not device_names:
+        render("devices cannot be empty.")
+        raise typer.Exit(1)
+    if len(device_names) > 1000:
+        render("Cannot remove more than 1000 devices at a time.")
+        raise typer.Exit(1)
+
+    request_device_ids = []
+    for device_name in device_names:
+        try:
+            search_response = device_client.get_all_devices(
+                enterprise_id, limit=1, offset=0, name=device_name
+            )
+            if not search_response.results:
+                render(f"Device does not exist with name {device_name}")
+                raise typer.Exit(1)
+            request_device_ids.append(search_response.results[0].id)
+        except ApiException as e:
+            state.log.error(f"[group-remove] Failed to list devices: {e}")
+            render(f"ERROR: {parse_error_message(e)}")
+            raise typer.Exit(1)
+
+    current_ids = _get_group_device_ids(device_client, enterprise_id, gid)
+    extra = list(set(request_device_ids) - set(current_ids))
+    if extra:
+        render("The given devices are not present in the group.")
+        raise typer.Exit(1)
+
+    data = DeviceGroupPartialUpdate()
+    data.device_ids = request_device_ids
+
+    try:
+        response = group_client.partial_update_group(gid, enterprise_id, data, action="remove")
+    except ApiException as e:
+        state.log.error(f"[group-remove] Failed to remove devices: {e}")
+        render(f"ERROR: {parse_error_message(e)}")
+        raise typer.Exit(1)
+
+    if not json_output:
+        render(_group_basic_response(response), format=OutputFormat.TABULATED.value, headers="keys", tablefmt="plain")
+    else:
+        render(_group_basic_response(response, OutputFormat.JSON), format=OutputFormat.JSON.value)
+
+
+@app.command("devices")
+def group_devices(
+    group: Optional[str] = typer.Option(None, "--group", "-g", help="Group name", shell_complete=group_name_complete),
+    group_id: Optional[str] = typer.Option(None, "--groupid", "-id", help="Group ID"),
+    limit: int = typer.Option(20, "--limit", "-l", help="Results per page"),
+    offset: int = typer.Option(0, "--offset", "-i", help="Initial index"),
+    json_output: bool = typer.Option(False, "--json", "-j", help="Render result in JSON format"),
+):
+    """List devices in a group."""
+    validate_creds()
+    db = DBWrapper(state.creds)
+    group_client = APIClient(db.get_configure()).get_group_api_client()
+    device_client = APIClient(db.get_configure()).get_device_api_client()
+    enterprise_id = db.get_enterprise_id()
+
+    if group or group_id:
+        gid, _ = _resolve_group_by_name_or_id(
+            group_client, enterprise_id, group, group_id, "group-devices"
+        )
+    else:
+        active = db.get_group()
+        if active is None or active.get("name") is None:
+            render("There is no active group.")
+            raise typer.Exit(1)
+        gid = active.get("id")
+
+    try:
+        response = device_client.get_all_devices(enterprise_id, group=gid, limit=limit, offset=offset)
+    except ApiException as e:
+        state.log.error(f"[group-devices] Failed to list group devices: {e}")
+        render(f"ERROR: {parse_error_message(e)}")
+        raise typer.Exit(1)
+
+    render(f"Number of Devices: {response.count}")
+    if not json_output:
+        label = {"id": "ID", "name": "NAME", "model": "MODEL",
+                 "state": "CURRENT STATE", "tags": "TAGS"}
+        devices = []
+        for d in response.results:
+            dev_name = d.alias_name if d.alias_name else d.device_name
+            tags = ", ".join(d.tags) if d.tags else ""
+            devices.append({
+                label["id"]: d.id, label["name"]: dev_name,
+                label["model"]: d.hardware_info.get("manufacturer"),
+                label["state"]: DeviceState(d.status).name,
+                label["tags"]: tags,
+            })
+        render(devices, format=OutputFormat.TABULATED.value, headers="keys", tablefmt="plain")
+    else:
+        devices = []
+        for d in response.results:
+            dev_name = d.alias_name if d.alias_name else d.device_name
+            devices.append({
+                "id": d.id, "device": dev_name,
+                "model": d.hardware_info.get("manufacturer"),
+                "state": DeviceState(d.status).name,
+                "tags": d.tags,
+            })
+        render(devices, format=OutputFormat.JSON.value)
+
+
+@app.command("move")
+def group_move(
+    group: Optional[str] = typer.Option(None, "--group", "-g", help="Group name", shell_complete=group_name_complete),
+    group_id: Optional[str] = typer.Option(None, "--groupid", "-id", help="Group ID"),
+    parent: Optional[str] = typer.Option(None, "--parent", "-p", help="New parent group name"),
+    parent_id: Optional[str] = typer.Option(None, "--parentid", "-pid", help="New parent group ID"),
+    json_output: bool = typer.Option(False, "--json", "-j", help="Render result in JSON format"),
+):
+    """Move a group to a different parent."""
+    validate_creds()
+    db = DBWrapper(state.creds)
+    group_client = APIClient(db.get_configure()).get_group_api_client()
+    enterprise_id = db.get_enterprise_id()
+
+    if group or group_id:
+        gid, group_obj = _resolve_group_by_name_or_id(
+            group_client, enterprise_id, group, group_id, "group-move"
+        )
+        group_name = group_obj.name if group_obj else group
+    else:
+        active = db.get_group()
+        if active is None or active.get("name") is None:
+            render("There is no active group.")
+            raise typer.Exit(1)
+        gid = active.get("id")
+        group_name = active.get("name")
+
+    if not parent_id and not parent:
+        render("Either parent name or parent id should be present.")
+        raise typer.Exit(1)
+
+    if parent_id:
+        try:
+            parent_obj = group_client.get_group_by_id(parent_id, enterprise_id)
+            if parent and parent != parent_obj.name:
+                render(f"Group does not exist with id {parent_id} and name {parent}")
+                raise typer.Exit(1)
+            data = DeviceGroupUpdate(name=group_name, parent=parent_id)
+        except ApiException as e:
+            state.log.error(f"[group-move] Group does not exist with id {parent_id}: {e}")
+            render(f"ERROR: {parse_error_message(e)}")
+            raise typer.Exit(1)
+    else:
+        try:
+            search_response = group_client.get_all_groups(
+                enterprise_id, limit=1, offset=0, name=parent
+            )
+            if not search_response.results:
+                render(f"Group does not exist with name {parent}")
+                raise typer.Exit(1)
+            pid = search_response.results[0].id
+            data = DeviceGroupUpdate(name=group_name, parent=pid)
+        except ApiException as e:
+            state.log.error(f"[group-move] Failed to list groups: {e}")
+            render(f"ERROR: {parse_error_message(e)}")
+            raise typer.Exit(1)
+
+    try:
+        response = group_client.partial_update_group(gid, enterprise_id, data, action="move")
+    except ApiException as e:
+        state.log.error(f"[group-move] Failed to move group: {e}")
+        render(f"ERROR: {parse_error_message(e)}")
+        raise typer.Exit(1)
+
+    if not json_output:
+        render(_group_basic_response(response), format=OutputFormat.TABULATED.value, headers="keys", tablefmt="plain")
+    else:
+        render(_group_basic_response(response, OutputFormat.JSON), format=OutputFormat.JSON.value)

--- a/esper/cli/group_command.py
+++ b/esper/cli/group_command.py
@@ -1,0 +1,226 @@
+"""
+Group command controller — replaces esper/controllers/device/group_command.py.
+`espercli group-command show/install/ping/lock/reboot`
+"""
+from ast import literal_eval
+from typing import Optional
+
+import typer
+from esperclient import GroupCommandRequest
+from esperclient.rest import ApiException
+
+from esper.cli.completions import group_name_complete
+from esper.cli.output import render
+from esper.cli.state import state, validate_creds, parse_error_message
+from esper.controllers.enums import DeviceCommandEnum, OutputFormat
+from esper.ext.api_client import APIClient
+from esper.ext.db_wrapper import DBWrapper
+
+app = typer.Typer(help="Fire commands at a group of devices")
+
+
+# ---------------------------------------------------------------------------
+# Shared helpers
+# ---------------------------------------------------------------------------
+
+def _command_basic_response(command, fmt=OutputFormat.TABULATED):
+    valid_keys = ["id", "command", "state"]
+
+    success = failed = in_progress = inactive = None
+    success_list: list = []
+    failed_list: list = []
+    inactive_list: list = []
+    in_progress_list: list = []
+
+    if command.details:
+        details = literal_eval(command.details)
+        if details.get("success"):
+            success_list = [d.get("name") for d in details["success"]]
+            success = "\n".join(success_list) if success_list else None
+        if details.get("failed"):
+            failed_list = [d.get("name") for d in details["failed"]]
+            failed = "\n".join(failed_list) if failed_list else None
+        if details.get("inactive"):
+            inactive_list = [d.get("name") for d in details["inactive"]]
+            inactive = "\n".join(inactive_list) if inactive_list else None
+        for key in ("acknowledge", "initiate", "in_progress", "timeout"):
+            if details.get(key):
+                in_progress_list.extend([d.get("name") for d in details[key]])
+        in_progress = "\n".join(in_progress_list) if in_progress_list else None
+
+    if fmt == OutputFormat.TABULATED:
+        title, det = "TITLE", "DETAILS"
+        renderable = [{title: k, det: v} for k, v in command.to_dict().items() if k in valid_keys]
+        renderable.extend([
+            {title: "success", det: success},
+            {title: "failed", det: failed},
+            {title: "in_progress", det: in_progress},
+            {title: "inactive", det: inactive},
+        ])
+    else:
+        renderable = {k: v for k, v in command.to_dict().items() if k in valid_keys}
+        renderable.update({"success": success_list, "failed": failed_list,
+                           "in_progress": in_progress_list, "inactive": inactive_list})
+    return renderable
+
+
+def _resolve_group_id(db, enterprise_id, group_name: Optional[str], tag: str) -> str:
+    """Return group_id for the given name or fall back to the active group."""
+    group_client = APIClient(db.get_configure()).get_group_api_client()
+    if group_name:
+        try:
+            search_response = group_client.get_all_groups(
+                enterprise_id, limit=1, offset=0, name=group_name
+            )
+            if not search_response.results:
+                render(f"Group does not exist with name {group_name}")
+                raise typer.Exit(1)
+            return search_response.results[0].id
+        except ApiException as e:
+            state.log.error(f"[{tag}] Failed to list groups: {e}")
+            render(f"ERROR: {parse_error_message(e)}")
+            raise typer.Exit(1)
+    else:
+        group = db.get_group()
+        if group is None or group.get("name") is None:
+            render("There is no active group.")
+            raise typer.Exit(1)
+        return group.get("id")
+
+
+# ---------------------------------------------------------------------------
+# Commands
+# ---------------------------------------------------------------------------
+
+@app.command("show")
+def group_command_show(
+    command_id: str = typer.Argument(..., help="Group command ID"),
+    group: Optional[str] = typer.Option(None, "--group", "-g", help="Group name", shell_complete=group_name_complete),
+    json_output: bool = typer.Option(False, "--json", "-j", help="Render result in JSON format"),
+):
+    """Show group command details."""
+    validate_creds()
+    db = DBWrapper(state.creds)
+    command_client = APIClient(db.get_configure()).get_group_command_api_client()
+    enterprise_id = db.get_enterprise_id()
+    group_id = _resolve_group_id(db, enterprise_id, group, "group-command-show")
+
+    try:
+        response = command_client.get_group_command(command_id, group_id, enterprise_id)
+    except ApiException as e:
+        state.log.error(f"[group-command-show] Failed to show command: {e}")
+        render(f"ERROR: {parse_error_message(e)}")
+        raise typer.Exit(1)
+
+    if not json_output:
+        render(_command_basic_response(response), format=OutputFormat.TABULATED.value, headers="keys", tablefmt="plain")
+    else:
+        render(_command_basic_response(response, OutputFormat.JSON), format=OutputFormat.JSON.value)
+
+
+@app.command("install")
+def group_command_install(
+    group: Optional[str] = typer.Option(None, "--group", "-g", help="Group name", shell_complete=group_name_complete),
+    version: Optional[str] = typer.Option(None, "--version", "-V", help="Application version ID"),
+    json_output: bool = typer.Option(False, "--json", "-j", help="Render result in JSON format"),
+):
+    """Install an application version on a group of devices."""
+    validate_creds()
+    db = DBWrapper(state.creds)
+    command_client = APIClient(db.get_configure()).get_group_command_api_client()
+    enterprise_id = db.get_enterprise_id()
+    group_id = _resolve_group_id(db, enterprise_id, group, "group-command-install")
+
+    command_request = GroupCommandRequest(
+        command_args={"app_version": version},
+        command=DeviceCommandEnum.INSTALL.name,
+    )
+    try:
+        response = command_client.run_group_command(enterprise_id, group_id, command_request)
+    except ApiException as e:
+        state.log.error(f"[group-command-install] Failed to fire install command: {e}")
+        render(f"ERROR: {parse_error_message(e)}")
+        raise typer.Exit(1)
+
+    if not json_output:
+        render(_command_basic_response(response), format=OutputFormat.TABULATED.value, headers="keys", tablefmt="plain")
+    else:
+        render(_command_basic_response(response, OutputFormat.JSON), format=OutputFormat.JSON.value)
+
+
+@app.command("ping")
+def group_command_ping(
+    group: Optional[str] = typer.Option(None, "--group", "-g", help="Group name", shell_complete=group_name_complete),
+    json_output: bool = typer.Option(False, "--json", "-j", help="Render result in JSON format"),
+):
+    """Ping a group of devices (update heartbeat)."""
+    validate_creds()
+    db = DBWrapper(state.creds)
+    command_client = APIClient(db.get_configure()).get_group_command_api_client()
+    enterprise_id = db.get_enterprise_id()
+    group_id = _resolve_group_id(db, enterprise_id, group, "group-command-ping")
+
+    command_request = GroupCommandRequest(command=DeviceCommandEnum.UPDATE_HEARTBEAT.name)
+    try:
+        response = command_client.run_group_command(enterprise_id, group_id, command_request)
+    except ApiException as e:
+        state.log.error(f"[group-command-ping] Failed to fire ping command: {e}")
+        render(f"ERROR: {parse_error_message(e)}")
+        raise typer.Exit(1)
+
+    if not json_output:
+        render(_command_basic_response(response), format=OutputFormat.TABULATED.value, headers="keys", tablefmt="plain")
+    else:
+        render(_command_basic_response(response, OutputFormat.JSON), format=OutputFormat.JSON.value)
+
+
+@app.command("lock")
+def group_command_lock(
+    group: Optional[str] = typer.Option(None, "--group", "-g", help="Group name", shell_complete=group_name_complete),
+    json_output: bool = typer.Option(False, "--json", "-j", help="Render result in JSON format"),
+):
+    """Lock a group of devices."""
+    validate_creds()
+    db = DBWrapper(state.creds)
+    command_client = APIClient(db.get_configure()).get_group_command_api_client()
+    enterprise_id = db.get_enterprise_id()
+    group_id = _resolve_group_id(db, enterprise_id, group, "group-command-lock")
+
+    command_request = GroupCommandRequest(command=DeviceCommandEnum.LOCK.name)
+    try:
+        response = command_client.run_group_command(enterprise_id, group_id, command_request)
+    except ApiException as e:
+        state.log.error(f"[group-command-lock] Failed to fire lock command: {e}")
+        render(f"ERROR: {parse_error_message(e)}")
+        raise typer.Exit(1)
+
+    if not json_output:
+        render(_command_basic_response(response), format=OutputFormat.TABULATED.value, headers="keys", tablefmt="plain")
+    else:
+        render(_command_basic_response(response, OutputFormat.JSON), format=OutputFormat.JSON.value)
+
+
+@app.command("reboot")
+def group_command_reboot(
+    group: Optional[str] = typer.Option(None, "--group", "-g", help="Group name", shell_complete=group_name_complete),
+    json_output: bool = typer.Option(False, "--json", "-j", help="Render result in JSON format"),
+):
+    """Reboot a group of devices."""
+    validate_creds()
+    db = DBWrapper(state.creds)
+    command_client = APIClient(db.get_configure()).get_group_command_api_client()
+    enterprise_id = db.get_enterprise_id()
+    group_id = _resolve_group_id(db, enterprise_id, group, "group-command-reboot")
+
+    command_request = GroupCommandRequest(command=DeviceCommandEnum.REBOOT.name)
+    try:
+        response = command_client.run_group_command(enterprise_id, group_id, command_request)
+    except ApiException as e:
+        state.log.error(f"[group-command-reboot] Failed to fire reboot command: {e}")
+        render(f"ERROR: {parse_error_message(e)}")
+        raise typer.Exit(1)
+
+    if not json_output:
+        render(_command_basic_response(response), format=OutputFormat.TABULATED.value, headers="keys", tablefmt="plain")
+    else:
+        render(_command_basic_response(response, OutputFormat.JSON), format=OutputFormat.JSON.value)

--- a/esper/cli/heartbeat.py
+++ b/esper/cli/heartbeat.py
@@ -1,0 +1,168 @@
+# Heartbeat commands — last check-in time and online/offline status per device.
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from datetime import datetime, timezone
+from typing import Optional
+
+import typer
+from esperclient.rest import ApiException
+from rich.text import Text
+
+from esper.cli.completions import device_name_complete
+from esper.cli.output import render
+from esper.cli.state import state, validate_creds, parse_error_message
+from esper.controllers.enums import OutputFormat
+from esper.ext.api_client import APIClient
+from esper.ext.api_rest import api_get
+from esper.ext.db_wrapper import DBWrapper
+
+app = typer.Typer(help="Device heartbeat (last check-in) commands")
+
+
+def _ago(ts: str) -> str:
+    """Return a human-readable 'X days/hours ago' string from an ISO timestamp."""
+    try:
+        dt = datetime.fromisoformat(ts.replace("Z", "+00:00"))
+        delta = datetime.now(timezone.utc) - dt
+        days = delta.days
+        hours, rem = divmod(delta.seconds, 3600)
+        minutes = rem // 60
+        if days > 0:
+            return f"{days}d ago"
+        if hours > 0:
+            return f"{hours}h ago"
+        return f"{minutes}m ago"
+    except Exception:
+        return ts
+
+
+def _status_label(status: int) -> str:
+    return "ONLINE" if status == 1 else "OFFLINE"
+
+
+def _fetch_heartbeat(environment, api_key, eid, device_id):
+    return api_get(environment, api_key, f"/device/v0/heartbeat/{device_id}/")
+
+
+@app.command("list")
+def heartbeat_list(
+    as_json: bool = typer.Option(False, "--json", "-j", help="Output as JSON"),
+) -> None:
+    """Show last heartbeat for all devices, sorted by timestamp descending."""
+    validate_creds()
+    db = DBWrapper(state.creds)
+    cfg = db.get_configure()
+    environment = cfg.get("environment")
+    api_key = cfg.get("api_key")
+    eid = db.get_enterprise_id()
+    device_client = APIClient(cfg).get_device_api_client()
+
+    try:
+        response = device_client.get_all_devices(eid, limit=500, offset=0)
+        devices = response.results or []
+    except ApiException as e:
+        render(f"ERROR: {parse_error_message(e)}")
+        raise typer.Exit(1)
+
+    if not devices:
+        render("No devices found.")
+        raise typer.Exit(0)
+
+    device_map = {str(d.id): (d.alias_name or d.device_name) for d in devices}
+
+    results = []
+    with ThreadPoolExecutor(max_workers=10) as pool:
+        futures = {
+            pool.submit(_fetch_heartbeat, environment, api_key, eid, d.id): str(d.id)
+            for d in devices
+        }
+        for fut in as_completed(futures):
+            device_id = futures[fut]
+            try:
+                data = fut.result()
+                content = data.get("content", {})
+                results.append({
+                    "name": device_map.get(device_id, device_id),
+                    "device_id": device_id,
+                    "status": content.get("status", 0),
+                    "timestamp": content.get("timestamp", ""),
+                })
+            except Exception:
+                results.append({
+                    "name": device_map.get(device_id, device_id),
+                    "device_id": device_id,
+                    "status": 0,
+                    "timestamp": "",
+                })
+
+    results.sort(key=lambda r: r["timestamp"], reverse=True)
+
+    if as_json:
+        render(results, format=OutputFormat.JSON.value)
+        return
+
+    rows = [
+        {
+            "NAME": r["name"],
+            "STATUS": _status_label(r["status"]),
+            "LAST SEEN": r["timestamp"],
+            "AGO": _ago(r["timestamp"]) if r["timestamp"] else "—",
+        }
+        for r in results
+    ]
+    render(rows, format=OutputFormat.TABULATED.value, headers="keys", tablefmt="plain")
+
+
+@app.command("show")
+def heartbeat_show(
+    device_name: Optional[str] = typer.Option(
+        None, "--device", "-d", help="Device name",
+        shell_complete=device_name_complete,
+    ),
+    as_json: bool = typer.Option(False, "--json", "-j", help="Output as JSON"),
+) -> None:
+    """Show heartbeat for a single device."""
+    validate_creds()
+    db = DBWrapper(state.creds)
+    cfg = db.get_configure()
+    environment = cfg.get("environment")
+    api_key = cfg.get("api_key")
+    eid = db.get_enterprise_id()
+    device_client = APIClient(cfg).get_device_api_client()
+
+    if not device_name:
+        render("ERROR: Specify a device with --device NAME")
+        raise typer.Exit(1)
+
+    try:
+        resp = device_client.get_all_devices(eid, limit=1, offset=0, name=device_name)
+        if not resp.results:
+            render(f"ERROR: Device not found: {device_name}")
+            raise typer.Exit(1)
+        device_id = str(resp.results[0].id)
+    except ApiException as e:
+        render(f"ERROR: {parse_error_message(e)}")
+        raise typer.Exit(1)
+
+    try:
+        data = api_get(environment, api_key, f"/device/v0/heartbeat/{device_id}/")
+    except Exception as e:
+        render(f"ERROR: {e}")
+        raise typer.Exit(1)
+
+    content = data.get("content", {})
+
+    if as_json:
+        render(content, format=OutputFormat.JSON.value)
+        return
+
+    ts = content.get("timestamp", "")
+    status = content.get("status", 0)
+    rows = [
+        {
+            "NAME": device_name,
+            "STATUS": _status_label(status),
+            "LAST SEEN": ts,
+            "AGO": _ago(ts) if ts else "—",
+        }
+    ]
+    render(rows, format=OutputFormat.TABULATED.value, headers="keys", tablefmt="plain")

--- a/esper/cli/heartbeat.py
+++ b/esper/cli/heartbeat.py
@@ -57,8 +57,14 @@ def heartbeat_list(
     device_client = APIClient(cfg).get_device_api_client()
 
     try:
-        response = device_client.get_all_devices(eid, limit=500, offset=0)
-        devices = response.results or []
+        devices = []
+        page_size, offset = 100, 0
+        while True:
+            page = device_client.get_all_devices(eid, limit=page_size, offset=offset)
+            devices.extend(page.results or [])
+            if len(devices) >= (page.count or 0) or not page.results:
+                break
+            offset += page_size
     except ApiException as e:
         render(f"ERROR: {parse_error_message(e)}")
         raise typer.Exit(1)

--- a/esper/cli/installs.py
+++ b/esper/cli/installs.py
@@ -1,0 +1,103 @@
+"""
+Application installs commands — replaces esper/controllers/device/install.py.
+`espercli installs list`
+"""
+from typing import Optional
+
+import typer
+from esperclient.rest import ApiException
+
+from esper.cli.output import render
+from esper.cli.state import state, validate_creds, parse_error_message
+from esper.controllers.enums import OutputFormat
+from esper.ext.api_client import APIClient
+from esper.ext.db_wrapper import DBWrapper
+
+app = typer.Typer(help="Application install commands")
+
+
+@app.command("list")
+def installs_list(
+    device: Optional[str] = typer.Option(None, "--device", "-d", help="Device name"),
+    appname: Optional[str] = typer.Option(None, "--appname", "-an", help="Application name"),
+    package: Optional[str] = typer.Option(None, "--package", "-p", help="Package name"),
+    state_filter: Optional[str] = typer.Option(None, "--state", "-s", help="Install state"),
+    limit: int = typer.Option(20, "--limit", "-l", help="Results per page"),
+    offset: int = typer.Option(0, "--offset", "-i", help="Initial index"),
+    json_output: bool = typer.Option(False, "--json", "-j", help="Render result in JSON format"),
+):
+    """List application installs on a device."""
+    validate_creds()
+    db = DBWrapper(state.creds)
+    device_client = APIClient(db.get_configure()).get_device_api_client()
+    enterprise_id = db.get_enterprise_id()
+
+    if device:
+        try:
+            search_response = device_client.get_all_devices(
+                enterprise_id, limit=1, offset=0, name=device
+            )
+            if not search_response.results:
+                render(f"Device does not exist with name {device}")
+                raise typer.Exit(1)
+            device_id = search_response.results[0].id
+        except ApiException as e:
+            state.log.error(f"[installs-list] Failed to list devices: {e}")
+            render(f"ERROR: {parse_error_message(e)}")
+            raise typer.Exit(1)
+    else:
+        dev = db.get_device()
+        if not dev or not dev.get("id"):
+            render("There is no active device.")
+            raise typer.Exit(1)
+        device_id = dev.get("id")
+
+    kwargs = {}
+    if appname:
+        kwargs["application_name"] = appname
+    if package:
+        kwargs["package_name"] = package
+    if state_filter:
+        kwargs["install_state"] = state_filter
+
+    try:
+        response = device_client.get_app_installs(
+            enterprise_id, device_id, limit=limit, offset=offset, **kwargs
+        )
+    except ApiException as e:
+        state.log.error(f"[installs-list] Failed to list installs: {e}")
+        render(f"ERROR: {parse_error_message(e)}")
+        raise typer.Exit(1)
+
+    render(f"Total Number of Installs: {response.count}")
+    if not json_output:
+        label = {
+            "id": "ID",
+            "application_name": "APPLICATION",
+            "package_name": "PACKAGE",
+            "version_code": "VERSION",
+            "install_state": "STATE",
+        }
+        installs = [
+            {
+                label["id"]: i.id,
+                label["application_name"]: i.application.application_name,
+                label["package_name"]: i.application.package_name,
+                label["version_code"]: i.application.version.version_code,
+                label["install_state"]: i.install_state,
+            }
+            for i in response.results
+        ]
+        render(installs, format=OutputFormat.TABULATED.value, headers="keys", tablefmt="plain")
+    else:
+        installs = [
+            {
+                "id": i.id,
+                "application_name": i.application.application_name,
+                "package_name": i.application.package_name,
+                "version_code": i.application.version.version_code,
+                "install_state": i.install_state,
+            }
+            for i in response.results
+        ]
+        render(installs, format=OutputFormat.JSON.value)

--- a/esper/cli/location.py
+++ b/esper/cli/location.py
@@ -10,7 +10,7 @@ from esper.cli.output import render
 from esper.cli.state import state, validate_creds, parse_error_message
 from esper.controllers.enums import OutputFormat
 from esper.ext.api_client import APIClient
-from esper.ext.api_rest import api_get
+from esper.ext.api_rest import api_get, api_get_all
 from esper.ext.db_wrapper import DBWrapper
 
 app = typer.Typer(help="Device location commands")
@@ -24,12 +24,23 @@ def _extract_device_id(url: str) -> Optional[str]:
 
 
 def _build_device_map(device_client, eid: str) -> dict:
-    """Return {device_id_str: name} for all devices."""
-    try:
-        resp = device_client.get_all_devices(eid, limit=500, offset=0)
-        return {str(d.id): (d.alias_name or d.device_name) for d in (resp.results or [])}
-    except ApiException:
-        return {}
+    """Return {device_id_str: name} for all devices (auto-paginated)."""
+    from esper.cli.state import state as _state
+    page_size = 100
+    offset = 0
+    mapping: dict = {}
+    while True:
+        try:
+            resp = device_client.get_all_devices(eid, limit=page_size, offset=offset)
+        except ApiException as e:
+            _state.log.error(f"[location] Failed to fetch device list at offset {offset}: {e}")
+            break
+        for d in resp.results or []:
+            mapping[str(d.id)] = d.alias_name or d.device_name
+        if len(mapping) >= (resp.count or 0) or not resp.results:
+            break
+        offset += page_size
+    return mapping
 
 
 def _city_state(item: dict) -> str:
@@ -51,12 +62,11 @@ def location_list(
     device_client = APIClient(cfg).get_device_api_client()
 
     try:
-        data = api_get(environment, api_key, f"/v1/enterprise/{eid}/report/location/", limit=100)
+        items = api_get_all(environment, api_key, f"/v1/enterprise/{eid}/report/location/")
     except Exception as e:
         render(f"ERROR: {e}")
         raise typer.Exit(1)
 
-    items = data if isinstance(data, list) else data.get("results", data.get("content", []))
     if not items:
         render("No location data found.")
         raise typer.Exit(0)
@@ -118,12 +128,11 @@ def location_show(
         raise typer.Exit(1)
 
     try:
-        data = api_get(environment, api_key, f"/v1/enterprise/{eid}/report/location/", limit=100)
+        items = api_get_all(environment, api_key, f"/v1/enterprise/{eid}/report/location/")
     except Exception as e:
         render(f"ERROR: {e}")
         raise typer.Exit(1)
 
-    items = data if isinstance(data, list) else data.get("results", data.get("content", []))
     match = None
     for item in items:
         did = _extract_device_id(item.get("device", ""))

--- a/esper/cli/location.py
+++ b/esper/cli/location.py
@@ -1,0 +1,155 @@
+# Location commands — GPS coordinates for devices.
+from typing import Optional
+import re
+
+import typer
+from esperclient.rest import ApiException
+
+from esper.cli.completions import device_name_complete
+from esper.cli.output import render
+from esper.cli.state import state, validate_creds, parse_error_message
+from esper.controllers.enums import OutputFormat
+from esper.ext.api_client import APIClient
+from esper.ext.api_rest import api_get
+from esper.ext.db_wrapper import DBWrapper
+
+app = typer.Typer(help="Device location commands")
+
+_DEVICE_ID_RE = re.compile(r"/device/([^/]+)/?$")
+
+
+def _extract_device_id(url: str) -> Optional[str]:
+    m = _DEVICE_ID_RE.search(url or "")
+    return m.group(1) if m else None
+
+
+def _build_device_map(device_client, eid: str) -> dict:
+    """Return {device_id_str: name} for all devices."""
+    try:
+        resp = device_client.get_all_devices(eid, limit=500, offset=0)
+        return {str(d.id): (d.alias_name or d.device_name) for d in (resp.results or [])}
+    except ApiException:
+        return {}
+
+
+def _city_state(item: dict) -> str:
+    parts = [p for p in [item.get("city"), item.get("state"), item.get("country")] if p]
+    return ", ".join(parts) if parts else "—"
+
+
+@app.command("list")
+def location_list(
+    as_json: bool = typer.Option(False, "--json", "-j", help="Output as JSON"),
+) -> None:
+    """Show GPS location for all devices."""
+    validate_creds()
+    db = DBWrapper(state.creds)
+    cfg = db.get_configure()
+    environment = cfg.get("environment")
+    api_key = cfg.get("api_key")
+    eid = db.get_enterprise_id()
+    device_client = APIClient(cfg).get_device_api_client()
+
+    try:
+        data = api_get(environment, api_key, f"/v1/enterprise/{eid}/report/location/", limit=100)
+    except Exception as e:
+        render(f"ERROR: {e}")
+        raise typer.Exit(1)
+
+    items = data if isinstance(data, list) else data.get("results", data.get("content", []))
+    if not items:
+        render("No location data found.")
+        raise typer.Exit(0)
+
+    device_map = _build_device_map(device_client, eid)
+
+    if as_json:
+        out = []
+        for item in items:
+            did = _extract_device_id(item.get("device", ""))
+            out.append({
+                "name": device_map.get(did, did or "unknown"),
+                "latitude": item.get("latitude"),
+                "longitude": item.get("longitude"),
+                "city_state": _city_state(item),
+                "last_updated_on": item.get("last_updated_on"),
+            })
+        render(out, format=OutputFormat.JSON.value)
+        return
+
+    rows = []
+    for item in items:
+        did = _extract_device_id(item.get("device", ""))
+        rows.append({
+            "NAME": device_map.get(did, did or "unknown"),
+            "LAT": item.get("latitude", "—"),
+            "LON": item.get("longitude", "—"),
+            "CITY/STATE": _city_state(item),
+            "LAST UPDATED": item.get("last_updated_on", "—"),
+        })
+    render(rows, format=OutputFormat.TABULATED.value, headers="keys", tablefmt="plain")
+
+
+@app.command("show")
+def location_show(
+    device_name: str = typer.Option(
+        ..., "--device", "-d", help="Device name",
+        shell_complete=device_name_complete,
+    ),
+    as_json: bool = typer.Option(False, "--json", "-j", help="Output as JSON"),
+) -> None:
+    """Show GPS location for one device."""
+    validate_creds()
+    db = DBWrapper(state.creds)
+    cfg = db.get_configure()
+    environment = cfg.get("environment")
+    api_key = cfg.get("api_key")
+    eid = db.get_enterprise_id()
+    device_client = APIClient(cfg).get_device_api_client()
+
+    try:
+        resp = device_client.get_all_devices(eid, limit=1, offset=0, name=device_name)
+        if not resp.results:
+            render(f"ERROR: Device not found: {device_name}")
+            raise typer.Exit(1)
+        device_id = str(resp.results[0].id)
+    except ApiException as e:
+        render(f"ERROR: {parse_error_message(e)}")
+        raise typer.Exit(1)
+
+    try:
+        data = api_get(environment, api_key, f"/v1/enterprise/{eid}/report/location/", limit=100)
+    except Exception as e:
+        render(f"ERROR: {e}")
+        raise typer.Exit(1)
+
+    items = data if isinstance(data, list) else data.get("results", data.get("content", []))
+    match = None
+    for item in items:
+        did = _extract_device_id(item.get("device", ""))
+        if did == device_id:
+            match = item
+            break
+
+    if not match:
+        render(f"No location data found for device {device_name}.")
+        raise typer.Exit(0)
+
+    if as_json:
+        render({
+            "name": device_name,
+            "latitude": match.get("latitude"),
+            "longitude": match.get("longitude"),
+            "city_state": _city_state(match),
+            "last_updated_on": match.get("last_updated_on"),
+        }, format=OutputFormat.JSON.value)
+        return
+
+    rows = [{
+        "NAME": device_name,
+        "LAT": match.get("latitude", "—"),
+        "LON": match.get("longitude", "—"),
+        "CITY/STATE": _city_state(match),
+        "LAST UPDATED": match.get("last_updated_on", "—"),
+    }]
+    render(rows, format=OutputFormat.TABULATED.value, headers="keys", tablefmt="plain")

--- a/esper/cli/operation.py
+++ b/esper/cli/operation.py
@@ -1,0 +1,261 @@
+"""
+Pipeline Stage Operation commands — nested under `pipeline stage`.
+`espercli pipeline stage operation create/edit/show/remove`
+"""
+from enum import Enum
+from typing import Optional
+
+import typer
+from esperclient.rest import ApiException
+
+from esper.cli.output import render, prompt_options
+from esper.cli.state import state, validate_creds, parse_error_message
+from esper.controllers.enums import OutputFormat
+from esper.ext.api_client import APIClient
+from esper.ext.db_wrapper import DBWrapper
+from esper.ext.pipeline_api import (
+    get_operation_url, create_operation, edit_operation, list_stages,
+    delete_api, APIException as PipelineAPIException, render_single_dict,
+    get_group_command_url,
+)
+
+app = typer.Typer(help="Pipeline Stage Operation commands")
+
+
+class ActionEnums(Enum):
+    APP_INSTALL = "App Install to a Group of Devices"
+    APP_UNINSTALL = "App Uninstall to a Group of Devices"
+    REBOOT = "Reboot a Group of Devices"
+
+    @classmethod
+    def choices_values(cls):
+        return [member.value for member in cls]
+
+
+def _prompt_action() -> str:
+    """Interactively prompt for an action type and return the enum name."""
+    choices = ActionEnums.choices_values()
+    options = [{"selector": i + 1, "prompt": v, "return": v} for i, v in enumerate(choices)]
+    selected_value = prompt_options("Action for this Operation:", options=options)
+    return ActionEnums(selected_value).name
+
+
+def _validate_group_name(db, group_name: str):
+    """Look up a group by name; raise ApiException if not found."""
+    group_client = APIClient(db.get_configure()).get_group_api_client()
+    enterprise_id = db.get_enterprise_id()
+    response = group_client.get_all_groups(enterprise_id, name=group_name)
+    if response.count > 0:
+        return response.results[0]
+    raise ApiException("No such Group-Name found!")
+
+
+# ---------------------------------------------------------------------------
+# Commands
+# ---------------------------------------------------------------------------
+
+@app.command("create")
+def operation_create(
+    pipeline_id: Optional[str] = typer.Option(None, "--pipeline-id", "-p", help="Pipeline ID"),
+    stage_id: Optional[str] = typer.Option(None, "--stage-id", "-s", help="Stage ID"),
+    name: Optional[str] = typer.Option(None, "--name", "-n", help="Operation name"),
+    action: Optional[str] = typer.Option(None, "--action", "-a", help="Action for this operation"),
+    group_name: Optional[str] = typer.Option(None, "--group", "-g", help="Group name for commands"),
+    desc: Optional[str] = typer.Option(None, "--desc", help="Operation description"),
+):
+    """Add an Operation to a Stage."""
+    validate_creds()
+    db = DBWrapper(state.creds)
+    environment = db.get_configure().get("environment")
+    enterprise_id = db.get_enterprise_id()
+    api_key = db.get_configure().get("api_key")
+
+    if not pipeline_id:
+        pipeline_id = typer.prompt("Enter the Pipeline ID")
+    if not stage_id:
+        stage_id = typer.prompt("Enter the Stage ID")
+    if not name:
+        name = typer.prompt("Name of the Operation")
+    if not action:
+        action = _prompt_action()
+    if not group_name:
+        group_name = typer.prompt("Name of the Group (to which the command must be fired)")
+
+    try:
+        group_obj = _validate_group_name(db, group_name)
+        group_url = get_group_command_url(environment, enterprise_id, group_obj.id)
+    except ApiException as e:
+        state.log.error(f"[operation-create] Failed to find group '{group_name}': {e}")
+        render(f"ERROR: {parse_error_message(e)}")
+        raise typer.Exit(1)
+
+    if desc is None:
+        desc = typer.prompt("Description for this Operation [optional]", default="")
+
+    url = get_operation_url(environment, enterprise_id, pipeline_id, stage_id)
+    try:
+        response = create_operation(url, api_key, name, action, desc, group_url)
+    except PipelineAPIException:
+        render("ERROR in connecting to Environment!")
+        raise typer.Exit(1)
+
+    if not response.ok:
+        _handle_operation_error(response, "operation-create")
+        raise typer.Exit(1)
+
+    data = render_single_dict(response.json())
+    render("Added Operation to Stage Successfully! Details:")
+    render(data, format=OutputFormat.TABULATED.value, headers="keys", tablefmt="plain")
+
+
+@app.command("edit")
+def operation_edit(
+    pipeline_id: Optional[str] = typer.Option(None, "--pipeline-id", "-p", help="Pipeline ID"),
+    stage_id: Optional[str] = typer.Option(None, "--stage-id", "-s", help="Stage ID"),
+    operation_id: Optional[str] = typer.Option(None, "--operation-id", "-o", help="Operation ID"),
+    name: Optional[str] = typer.Option(None, "--name", "-n", help="New operation name"),
+    action: Optional[str] = typer.Option(None, "--action", "-a", help="New action"),
+    desc: Optional[str] = typer.Option(None, "--desc", help="New description"),
+):
+    """Edit an Operation."""
+    validate_creds()
+    db = DBWrapper(state.creds)
+    environment = db.get_configure().get("environment")
+    enterprise_id = db.get_enterprise_id()
+    api_key = db.get_configure().get("api_key")
+
+    if not pipeline_id:
+        pipeline_id = typer.prompt("Enter the Pipeline ID")
+    if not stage_id:
+        stage_id = typer.prompt("Enter the Stage ID")
+    if not operation_id:
+        operation_id = typer.prompt("Enter the Operation ID")
+    if name is None:
+        name = typer.prompt("Change the name of the Operation", default="")
+    if desc is None:
+        desc = typer.prompt("Change the description [optional]", default="")
+    if not action:
+        action = _prompt_action()
+
+    url = get_operation_url(
+        environment, enterprise_id,
+        pipeline_id=pipeline_id, stage_id=stage_id, operation_id=operation_id,
+    )
+    try:
+        response = edit_operation(url, api_key, name, action, desc)
+    except PipelineAPIException:
+        render("ERROR in connecting to Environment!")
+        raise typer.Exit(1)
+
+    if not response.ok:
+        _handle_operation_error(response, "operation-edit")
+        raise typer.Exit(1)
+
+    data = render_single_dict(response.json())
+    render("Edited Operation for this Stage Successfully! Details:")
+    render(data, format=OutputFormat.TABULATED.value, headers="keys", tablefmt="plain")
+
+
+@app.command("show")
+def operation_show(
+    pipeline_id: Optional[str] = typer.Option(None, "--pipeline-id", "-p", help="Pipeline ID"),
+    stage_id: Optional[str] = typer.Option(None, "--stage-id", "-s", help="Stage ID"),
+):
+    """List all Operations in a Stage."""
+    validate_creds()
+    db = DBWrapper(state.creds)
+    environment = db.get_configure().get("environment")
+    enterprise_id = db.get_enterprise_id()
+    api_key = db.get_configure().get("api_key")
+
+    if not pipeline_id:
+        pipeline_id = typer.prompt("Enter the Pipeline ID")
+    if not stage_id:
+        stage_id = typer.prompt("Enter the Stage ID")
+
+    url = get_operation_url(environment, enterprise_id, pipeline_id=pipeline_id, stage_id=stage_id)
+    try:
+        response = list_stages(url, api_key)
+    except PipelineAPIException:
+        render("ERROR in connecting to Environment!")
+        raise typer.Exit(1)
+
+    if not response.ok:
+        _handle_operation_error(response, "operation-show")
+        raise typer.Exit(1)
+
+    data = response.json().get("results") or []
+    render_data = [
+        {
+            "ID": op.get("id"),
+            "NAME": op.get("name"),
+            "DESCRIPTION": op.get("description"),
+            "ORDERING": op.get("ordering"),
+            "ACTION": op.get("action"),
+            "VERSION": op.get("version"),
+        }
+        for op in data
+    ]
+
+    render("Listing Operations for the Stage! Details:")
+    render(render_data, format=OutputFormat.TABULATED.value, headers="keys", tablefmt="plain")
+
+
+@app.command("remove")
+def operation_remove(
+    pipeline_id: Optional[str] = typer.Option(None, "--pipeline-id", "-p", help="Pipeline ID"),
+    stage_id: Optional[str] = typer.Option(None, "--stage-id", "-s", help="Stage ID"),
+    operation_id: Optional[str] = typer.Option(None, "--operation-id", "-o", help="Operation ID"),
+):
+    """Remove an Operation from a Stage."""
+    validate_creds()
+    db = DBWrapper(state.creds)
+    environment = db.get_configure().get("environment")
+    enterprise_id = db.get_enterprise_id()
+    api_key = db.get_configure().get("api_key")
+
+    if not pipeline_id:
+        pipeline_id = typer.prompt("Enter the Pipeline ID")
+    if not stage_id:
+        stage_id = typer.prompt("Enter the Stage ID")
+    if not operation_id:
+        operation_id = typer.prompt("Enter the Operation ID")
+
+    url = get_operation_url(
+        environment, enterprise_id,
+        pipeline_id=pipeline_id, stage_id=stage_id, operation_id=operation_id,
+    )
+    try:
+        response = delete_api(url, api_key)
+    except PipelineAPIException:
+        render("ERROR in connecting to Environment!")
+        raise typer.Exit(1)
+
+    if not response.ok:
+        _handle_operation_error(response, "operation-remove")
+        raise typer.Exit(1)
+
+    render("Removed Operation for this Stage Successfully!")
+
+
+# ---------------------------------------------------------------------------
+# Internal
+# ---------------------------------------------------------------------------
+
+def _handle_operation_error(response, tag: str):
+    state.log.debug(f"[{tag}] Response not OK. Status: {response.status_code}")
+    if response.status_code == 400:
+        errors = response.json().get("meta", {}).get("non_field_errors")
+        if errors:
+            state.log.error(f"Validation Error: {errors}")
+        field_errors = response.json().get("errors")
+        if field_errors:
+            msg = response.json().get("message", "")
+            if "The fields pipeline, ordering must make a unique set." in msg:
+                state.log.error("Operation with same `name` already created for this Stage!")
+            else:
+                state.log.error(f"Validation Error: {field_errors}")
+    elif response.status_code == 404:
+        state.log.error("Stage URL not found!")
+    elif response.status_code == 500:
+        state.log.error(f"Internal Server Error! {response.json()}")

--- a/esper/cli/output.py
+++ b/esper/cli/output.py
@@ -1,0 +1,246 @@
+"""
+Central output helper — Rich-powered replacement for tabulate/typer.echo.
+
+All existing ``render()`` call sites work without any modification.  The
+improvement is entirely cosmetic/UX:
+
+* Colour-coded status values (green=OK, yellow=warning, red=fail, …)
+* Rich tables with an underlined header instead of plain text
+* Syntax-highlighted JSON output
+* Success messages get a leading "✓"; errors route to stderr in red
+* ``prompt_options()`` displays a styled numbered menu
+"""
+from __future__ import annotations
+
+import json as _json
+from typing import Any
+
+import typer
+from rich import reconfigure as _rich_reconfigure
+from rich.console import Console
+from rich.json import JSON as RichJSON
+from rich.panel import Panel
+from rich.table import Table, box
+from rich.text import Text
+
+from esper.controllers.enums import OutputFormat
+
+# ---------------------------------------------------------------------------
+# Consoles
+# ---------------------------------------------------------------------------
+console = Console(highlight=False)
+err_console = Console(stderr=True, highlight=False)
+
+# ---------------------------------------------------------------------------
+# Status → style mapping
+# Covers DeviceState names, CommandState names & their human-readable values.
+# ---------------------------------------------------------------------------
+_STATUS_STYLES: dict[str, str] = {
+    # ── Device states ─────────────────────────────────────────────────────
+    "ACTIVE": "bold green",
+    "ONBOARDED": "green",
+    "REGISTERED": "green",
+    "APPS_INSTALLED": "green",
+    "DEVICE_SETTINGS_PROCESSED": "green",
+    # Transitional / provisioning
+    "PROVISIONING_BEGIN": "yellow",
+    "GOOGLE_PLAY_CONFIGURATION": "yellow",
+    "POLICY_APPLICATION_IN_PROGRESS": "yellow",
+    "ONBOARDING_IN_PROGRESS": "yellow",
+    "AFW_ACCOUNT_ADDED": "yellow",
+    "BRANDING_PROCESSED": "yellow",
+    "PERMISSION_POLICY_PROCESSED": "yellow",
+    "DEVICE_POLICY_PROCESSED": "yellow",
+    "SECURITY_POLICY_PROCESSED": "yellow",
+    "PHONE_POLICY_PROCESSED": "yellow",
+    "CUSTOM_SETTINGS_PROCESSED": "yellow",
+    # Problem states
+    "INACTIVE": "yellow",
+    "DISABLED": "dim",
+    "ONBOARDING_FAILED": "bold red",
+    "WIPE_IN_PROGRESS": "bold red",
+    # ── V2 command states (names) ──────────────────────────────────────────
+    "SUCCESS": "bold green",
+    "FAILURE": "bold red",
+    "TIMEOUT": "red",
+    "IN_PROGRESS": "cyan",
+    "INITIATE": "cyan",
+    "ACKNOWLEDGE": "cyan",
+    "QUEUED": "blue",
+    "SCHEDULED": "blue",
+    "CANCELLED": "dim",
+    # ── V2 command states (human-readable values) ─────────────────────────
+    "Command Success": "bold green",
+    "Command Failure": "bold red",
+    "Command TimeOut": "red",
+    "Command In Progress": "cyan",
+    "Command Initiated": "cyan",
+    "Command Acknowledged": "cyan",
+    "Command Queued": "blue",
+    "Command Scheduled": "blue",
+    "Command Cancelled": "dim",
+}
+
+# Prefixes that indicate a successful action completed
+_SUCCESS_PREFIXES = (
+    "Created ", "Added ", "Edited ", "Removed ", "Deleted ",
+    "Unset ", "Uploaded ", "Updated ", "Renewed ",
+    "Pipeline execution",
+    "Version with id",
+    "Application with id",
+    "Content with id",
+)
+
+
+def _styled_value(value: Any) -> Text:
+    """Return a ``rich.Text`` with optional status styling for *value*."""
+    s = str(value) if value is not None else ""
+    style = _STATUS_STYLES.get(s)
+    return Text(s, style=style or "")
+
+
+# ---------------------------------------------------------------------------
+# Public helpers
+# ---------------------------------------------------------------------------
+
+def disable_color() -> None:
+    """Disable all ANSI colour (called when ``--no-color`` is passed)."""
+    _rich_reconfigure(no_color=True)
+
+
+def render(data, format=None, **kwargs) -> None:
+    """
+    Print *data* in the requested format.
+
+    Compatible with every calling convention used in the CLI modules::
+
+        render("some message")
+        render(list_of_dicts, format=OutputFormat.TABULATED.value,
+               headers="keys", tablefmt="plain")
+        render(dict_or_list, format=OutputFormat.JSON.value)
+    """
+    # ── Plain string ──────────────────────────────────────────────────────
+    if format is None or isinstance(data, str):
+        s = str(data).rstrip("\n")
+        if not s:
+            return
+        if s.upper().startswith("ERROR"):
+            err_console.print(f"[bold red]{s}[/bold red]")
+        elif any(s.startswith(p) for p in _SUCCESS_PREFIXES):
+            console.print(f"[bold green]✓[/bold green] {s}")
+        else:
+            console.print(s)
+
+    # ── Tabulated ─────────────────────────────────────────────────────────
+    elif format == OutputFormat.TABULATED.value:
+        if not data:
+            return
+        if isinstance(data, list) and data and isinstance(data[0], dict):
+            headers = list(data[0].keys())
+            tbl = Table(
+                box=box.SIMPLE_HEAD,
+                show_header=True,
+                header_style="bold cyan",
+                show_edge=False,
+                pad_edge=False,
+            )
+            for h in headers:
+                tbl.add_column(str(h), no_wrap=False, overflow="fold")
+            for row in data:
+                tbl.add_row(*[_styled_value(row.get(h)) for h in headers])
+            console.print(tbl)
+        else:
+            # Fallback (shouldn't normally happen)
+            from tabulate import tabulate as _tab
+            console.print(_tab(data, **kwargs))
+
+    # ── JSON ──────────────────────────────────────────────────────────────
+    elif format == OutputFormat.JSON.value:
+        console.print(RichJSON(_json.dumps(data, indent=2, default=str)))
+
+    else:
+        console.print(str(data))
+
+
+def install_rich_errors() -> None:
+    """
+    Patch Typer's ``rich_format_error`` so every usage-error automatically
+    shows the relevant help page immediately below the error, rather than
+    telling the user to go run ``--help`` themselves.
+
+    Typer already intercepts ``ClickException`` and routes it through
+    ``rich_utils.rich_format_error`` when Rich is available, so we hook
+    there rather than ``click.exceptions.UsageError.show``.
+
+    Call this once, early — ``app.py`` calls it before ``main()`` runs.
+    """
+    try:
+        from typer import rich_utils as _ru
+    except ImportError:
+        return  # Typer not installed or very old version — skip silently
+
+    def _enhanced_format_error(exc) -> None:  # noqa: ANN001
+        # Typer passes the exception as the first positional arg (not `self`)
+        ctx = getattr(exc, "ctx", None)
+        msg = exc.format_message()
+
+        # ── Build a short, human-readable error description ──────────────────
+        if "Missing argument" in msg and "'" in msg:
+            arg = msg.split("'")[1].lower().replace("_", " ")
+            description = f"[bold]{arg}[/bold] is required."
+        elif "Missing option" in msg and "'" in msg:
+            opt = msg.split("'")[1]
+            description = f"[bold]{opt}[/bold] is required."
+        elif "Got unexpected extra" in msg:
+            description = "Unexpected extra argument — check argument order."
+        else:
+            description = msg  # includes "Did you mean X?" from Click 8
+
+        # ── Error panel (compact — shown first) ──────────────────────────────
+        rich_console = _ru._get_rich_console(stderr=True)
+        rich_console.print(
+            Panel(
+                f"[bold red]✗[/bold red]  {description}",
+                title="[bold red]Error[/bold red]",
+                border_style="red",
+                expand=False,
+                padding=(0, 1),
+            )
+        )
+
+        # ── Full help for the relevant command (shown immediately after) ──────
+        if ctx is not None:
+            try:
+                _ru.rich_format_help(
+                    obj=ctx.command,
+                    ctx=ctx,
+                    markup_mode="rich",
+                )
+            except Exception:
+                # Fallback to plain text if rich_format_help fails for any reason
+                rich_console.print(ctx.get_help())
+
+    _ru.rich_format_error = _enhanced_format_error  # type: ignore[assignment]
+
+
+def prompt_options(prompt_text: str, options: list) -> str:
+    """
+    Styled numbered-menu prompt.
+
+    *options* is a list of dicts with keys ``"prompt"`` (display text) and
+    ``"return"`` (the value returned on selection).
+    """
+    console.print(f"\n[bold]{prompt_text}[/bold]")
+    for i, opt in enumerate(options, 1):
+        console.print(f"  [cyan]\\[{i}][/cyan] {opt['prompt']}")
+    while True:
+        raw = typer.prompt("Enter choice")
+        try:
+            choice = int(raw)
+            if 1 <= choice <= len(options):
+                return options[choice - 1]["return"]
+        except ValueError:
+            pass
+        err_console.print(
+            f"[red]Invalid choice.[/red]  Please enter a number between 1 and {len(options)}."
+        )

--- a/esper/cli/pipeline.py
+++ b/esper/cli/pipeline.py
@@ -1,0 +1,217 @@
+"""
+Pipeline commands — replaces esper/controllers/pipeline/pipeline.py.
+`espercli pipeline create/edit/show/remove`
+"""
+from enum import Enum
+from typing import Optional
+
+import typer
+
+from esper.cli.output import render, prompt_options
+from esper.cli.state import state, validate_creds
+from esper.controllers.enums import OutputFormat
+from esper.ext.db_wrapper import DBWrapper
+from esper.ext.pipeline_api import (
+    get_pipeline_url, create_pipeline, edit_pipeline,
+    list_pipelines, fetch_pipelines, delete_api, render_single_dict, APIException,
+)
+
+app = typer.Typer(help="Pipeline commands")
+
+
+class TriggerEventType(Enum):
+    NEW_APP_VERSION_EVENT = "NewAppVersionEvent"
+    MANUAL_PIPELINE_START_EVENT = "StartPipelineEvent"
+
+
+def _get_trigger_interactively():
+    """Prompt the user for a trigger type and return a trigger dict or None."""
+    choice = prompt_options(
+        "What type of trigger do you want for your Pipeline?",
+        options=[
+            {"selector": 1, "prompt": TriggerEventType.NEW_APP_VERSION_EVENT.value,
+             "return": TriggerEventType.NEW_APP_VERSION_EVENT.name},
+            {"selector": 2, "prompt": "Skip for now...", "return": "skip"},
+        ],
+    )
+    if choice == "skip":
+        return None
+    if choice == TriggerEventType.NEW_APP_VERSION_EVENT.name:
+        app_name = typer.prompt("Enter the Application name")
+        package_name = typer.prompt("Enter the Package name")
+        return {
+            "trigger_event": TriggerEventType.NEW_APP_VERSION_EVENT.value,
+            "pre_conditions": {"application_name": app_name, "package_name": package_name},
+        }
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Commands
+# ---------------------------------------------------------------------------
+
+@app.command("create")
+def pipeline_create(
+    name: Optional[str] = typer.Option(None, "--name", "-n", help="Pipeline name"),
+    desc: Optional[str] = typer.Option(None, "--desc", help="Pipeline description"),
+):
+    """Create a new pipeline."""
+    validate_creds()
+    db = DBWrapper(state.creds)
+    environment = db.get_configure().get("environment")
+    enterprise_id = db.get_enterprise_id()
+    api_key = db.get_configure().get("api_key")
+
+    if not name:
+        name = typer.prompt("Name of the Pipeline")
+    if desc is None:
+        desc = typer.prompt("Description for this Pipeline [optional]", default="")
+
+    trigger = _get_trigger_interactively()
+
+    url = get_pipeline_url(environment, enterprise_id)
+    try:
+        response = create_pipeline(url, api_key, name, desc, trigger)
+    except APIException:
+        render("ERROR in connecting to Environment!")
+        raise typer.Exit(1)
+
+    if not response.ok:
+        _handle_pipeline_error(response, "pipeline-create")
+        raise typer.Exit(1)
+
+    data = render_single_dict(response.json())
+    render("Created Pipeline Successfully! Details:")
+    render(data, format=OutputFormat.TABULATED.value, headers="keys", tablefmt="plain")
+
+
+@app.command("edit")
+def pipeline_edit(
+    pipeline_id: Optional[str] = typer.Option(None, "--pipeline-id", "-p", help="Pipeline ID"),
+    name: Optional[str] = typer.Option(None, "--name", "-n", help="New pipeline name"),
+    desc: Optional[str] = typer.Option(None, "--desc", help="New pipeline description"),
+):
+    """Edit a pipeline."""
+    validate_creds()
+    db = DBWrapper(state.creds)
+    environment = db.get_configure().get("environment")
+    enterprise_id = db.get_enterprise_id()
+    api_key = db.get_configure().get("api_key")
+
+    if not pipeline_id:
+        pipeline_id = typer.prompt("Enter the Pipeline ID")
+    if name is None:
+        name = typer.prompt("Change the name of the Pipeline", default="")
+    if desc is None:
+        desc = typer.prompt("Change the description [optional]", default="")
+
+    trigger = _get_trigger_interactively()
+
+    if not name and not desc and not trigger:
+        render("No changes requested. Exiting.")
+        return
+
+    url = get_pipeline_url(environment, enterprise_id, pipeline_id=pipeline_id)
+    try:
+        response = edit_pipeline(url, api_key, name, desc, trigger)
+    except APIException:
+        render("ERROR in connecting to Environment!")
+        raise typer.Exit(1)
+
+    if not response.ok:
+        _handle_pipeline_error(response, "pipeline-edit")
+        raise typer.Exit(1)
+
+    data = render_single_dict(response.json())
+    render("Edited Pipeline Successfully! Details:")
+    render(data, format=OutputFormat.TABULATED.value, headers="keys", tablefmt="plain")
+
+
+@app.command("show")
+def pipeline_show(
+    pipeline_id: Optional[str] = typer.Option(None, "--pipeline-id", "-p", help="Pipeline ID"),
+):
+    """List or fetch pipeline(s)."""
+    validate_creds()
+    db = DBWrapper(state.creds)
+    environment = db.get_configure().get("environment")
+    enterprise_id = db.get_enterprise_id()
+    api_key = db.get_configure().get("api_key")
+
+    url = get_pipeline_url(environment, enterprise_id, pipeline_id=pipeline_id)
+    try:
+        response = fetch_pipelines(url, api_key) if pipeline_id else list_pipelines(url, api_key)
+    except APIException:
+        render("ERROR in connecting to Environment!")
+        raise typer.Exit(1)
+
+    if not response.ok:
+        _handle_pipeline_error(response, "pipeline-show")
+        raise typer.Exit(1)
+
+    data = [response.json()] if pipeline_id else (response.json().get("results") or [])
+
+    render_data = []
+    for pipeline in data:
+        trigger_name = trigger_app = None
+        trigger = pipeline.get("trigger")
+        if trigger:
+            trigger_name = trigger.get("trigger_event")
+            pre = trigger.get("pre_conditions")
+            trigger_app = pre.get("application_name") if pre else None
+        render_data.append({
+            "ID": pipeline.get("id"),
+            "NAME": pipeline.get("name"),
+            "DESCRIPTION": pipeline.get("description"),
+            "STAGES": len(pipeline.get("stages", [])),
+            "VERSION": pipeline.get("version"),
+            "TRIGGER": trigger_name,
+            "TRIGGER-APP": trigger_app,
+        })
+
+    render("Listing Pipeline! Details:")
+    render(render_data, format=OutputFormat.TABULATED.value, headers="keys", tablefmt="plain")
+
+
+@app.command("remove")
+def pipeline_remove(
+    pipeline_id: Optional[str] = typer.Option(None, "--pipeline-id", "-p", help="Pipeline ID"),
+):
+    """Remove a pipeline."""
+    validate_creds()
+    db = DBWrapper(state.creds)
+    environment = db.get_configure().get("environment")
+    enterprise_id = db.get_enterprise_id()
+    api_key = db.get_configure().get("api_key")
+
+    if not pipeline_id:
+        pipeline_id = typer.prompt("Enter the Pipeline ID")
+
+    url = get_pipeline_url(environment, enterprise_id, pipeline_id=pipeline_id)
+    try:
+        response = delete_api(url, api_key)
+    except APIException:
+        render("ERROR in connecting to Environment!")
+        raise typer.Exit(1)
+
+    if not response.ok:
+        _handle_pipeline_error(response, "pipeline-remove")
+        raise typer.Exit(1)
+
+    render("Removed Pipeline Successfully!")
+
+
+# ---------------------------------------------------------------------------
+# Internal
+# ---------------------------------------------------------------------------
+
+def _handle_pipeline_error(response, tag: str):
+    state.log.debug(f"[{tag}] Response not OK. Status: {response.status_code}")
+    if response.status_code == 400:
+        errors = response.json().get("meta", {}).get("non_field_errors")
+        if errors:
+            state.log.error(f"Validation Error: {errors}")
+    elif response.status_code == 404:
+        state.log.error("Pipeline URL not found!")
+    elif response.status_code == 500:
+        state.log.error(f"Internal Server Error! {response.json()}")

--- a/esper/cli/policy.py
+++ b/esper/cli/policy.py
@@ -1,0 +1,100 @@
+# Policy commands — list, show, and delete enterprise policies.
+from typing import Optional
+
+import typer
+
+from esper.cli.output import render
+from esper.cli.state import state, validate_creds
+from esper.controllers.enums import OutputFormat
+from esper.ext.api_rest import api_delete, api_get
+from esper.ext.db_wrapper import DBWrapper
+
+app = typer.Typer(help="Policy management commands")
+
+
+@app.command("list")
+def policy_list(
+    as_json: bool = typer.Option(False, "--json", "-j", help="Output as JSON"),
+) -> None:
+    """List all enterprise policies."""
+    validate_creds()
+    db = DBWrapper(state.creds)
+    cfg = db.get_configure()
+    environment = cfg.get("environment")
+    api_key = cfg.get("api_key")
+    eid = db.get_enterprise_id()
+
+    try:
+        data = api_get(environment, api_key, f"/enterprise/{eid}/policy/")
+    except Exception as e:
+        render(f"ERROR: {e}")
+        raise typer.Exit(1)
+
+    items = data if isinstance(data, list) else data.get("results", data.get("content", []))
+    if not items:
+        render("No policies found.")
+        raise typer.Exit(0)
+
+    if as_json:
+        render(items, format=OutputFormat.JSON.value)
+        return
+
+    rows = [{"ID": p.get("id"), "POLICY NAME": p.get("policy_name", "—")} for p in items]
+    render(rows, format=OutputFormat.TABULATED.value, headers="keys", tablefmt="plain")
+
+
+@app.command("show")
+def policy_show(
+    policy_id: str = typer.Argument(..., help="Policy ID"),
+    as_json: bool = typer.Option(False, "--json", "-j", help="Output as JSON"),
+) -> None:
+    """Show details for a single policy."""
+    validate_creds()
+    db = DBWrapper(state.creds)
+    cfg = db.get_configure()
+    environment = cfg.get("environment")
+    api_key = cfg.get("api_key")
+    eid = db.get_enterprise_id()
+
+    try:
+        data = api_get(environment, api_key, f"/enterprise/{eid}/policy/{policy_id}/")
+    except Exception as e:
+        render(f"ERROR: {e}")
+        raise typer.Exit(1)
+
+    if as_json:
+        render(data, format=OutputFormat.JSON.value)
+        return
+
+    rows = [{"FIELD": k, "VALUE": str(v)} for k, v in data.items()]
+    render(rows, format=OutputFormat.TABULATED.value, headers="keys", tablefmt="plain")
+
+
+@app.command("delete")
+def policy_delete(
+    policy_id: str = typer.Argument(..., help="Policy ID"),
+    yes: bool = typer.Option(False, "--yes", "-y", help="Skip confirmation prompt"),
+) -> None:
+    """Delete a policy."""
+    validate_creds()
+
+    if not yes:
+        typer.confirm(f"Delete policy {policy_id}?", abort=True)
+
+    db = DBWrapper(state.creds)
+    cfg = db.get_configure()
+    environment = cfg.get("environment")
+    api_key = cfg.get("api_key")
+    eid = db.get_enterprise_id()
+
+    try:
+        status = api_delete(environment, api_key, f"/enterprise/{eid}/policy/{policy_id}/")
+    except Exception as e:
+        render(f"ERROR: {e}")
+        raise typer.Exit(1)
+
+    if status in (200, 204):
+        render(f"Deleted policy {policy_id}")
+    else:
+        render(f"ERROR: Unexpected status code {status}")
+        raise typer.Exit(1)

--- a/esper/cli/report_html.py
+++ b/esper/cli/report_html.py
@@ -1,0 +1,590 @@
+"""
+HTML dashboard generator for `espercli device report`.
+
+Produces a fully self-contained HTML file (no external assets except
+Chart.js from a CDN) that can be opened in any browser.
+"""
+from __future__ import annotations
+
+import json
+
+# ---------------------------------------------------------------------------
+# Colour helpers
+# ---------------------------------------------------------------------------
+
+def _battery_color(level) -> str:
+    if level is None:
+        return "#94a3b8"
+    if level > 60:
+        return "#4ade80"
+    if level > 20:
+        return "#fbbf24"
+    return "#f87171"
+
+
+def _battery_bg(level) -> str:
+    if level is None:
+        return "#1e293b"
+    if level > 60:
+        return "rgba(74,222,128,0.08)"
+    if level > 20:
+        return "rgba(251,191,36,0.08)"
+    return "rgba(248,113,113,0.08)"
+
+
+def _state_badge(state: str) -> str:
+    styles = {
+        "ACTIVE":   ("badge-green",  "✓ ACTIVE"),
+        "INACTIVE": ("badge-red",    "✗ INACTIVE"),
+        "DISABLED": ("badge-muted",  "— DISABLED"),
+    }
+    cls, label = styles.get(state.upper(), ("badge-muted", state))
+    return f'<span class="{cls}">{label}</span>'
+
+
+def _signal_dots(level) -> str:
+    """Render 5 signal-strength dots."""
+    if level is None:
+        return '<span class="muted">—</span>'
+    filled = int(level)
+    dots = ""
+    for i in range(5):
+        cls = "dot-filled" if i < filled else "dot-empty"
+        dots += f'<span class="{cls}">●</span>'
+    return dots
+
+
+def _mb_display(mb) -> str:
+    if mb is None:
+        return "—"
+    gb = mb / 1024
+    if gb >= 1:
+        return f"{gb:.1f} GB"
+    return f"{mb:,} MB"
+
+
+def _cmd_state_class(state: str) -> str:
+    s = (state or "").upper()
+    if "SUCCESS" in s:
+        return "cmd-success"
+    if "FAIL" in s or "ERROR" in s:
+        return "cmd-fail"
+    return "cmd-neutral"
+
+
+# ---------------------------------------------------------------------------
+# Main generator
+# ---------------------------------------------------------------------------
+
+def generate_html(d: dict) -> str:
+    """
+    *d* keys:
+      name, hardware_name, device_id, state, api_level, is_gms,
+      generated_at, status (dict), battery_telemetry (list of {x,y}),
+      temp_telemetry (list of {x,y}), commands (list of dicts),
+      installs_count (int)
+    """
+    name        = d.get("name", "Unknown Device")
+    hw_name     = d.get("hardware_name", "—")
+    dev_id      = d.get("device_id", "—")
+    state_val   = d.get("state", "UNKNOWN")
+    api_level   = d.get("api_level", "—")
+    is_gms      = "Yes" if d.get("is_gms") else "No"
+    generated   = d.get("generated_at", "")
+
+    status      = d.get("status") or {}
+    bat_level   = status.get("battery_level")
+    bat_temp    = status.get("battery_temperature")
+    storage_mb  = status.get("memory_storage")
+    ram_mb      = status.get("memory_ram")
+    link_speed  = status.get("link_speed")
+    sig_str     = status.get("signal_strength")
+
+    bat_pct_display = f"{bat_level}%" if bat_level is not None else "—"
+    bat_pct_val     = bat_level if bat_level is not None else 0
+    bat_temp_display = f"{bat_temp}°C" if bat_temp is not None else "—"
+    bat_color       = _battery_color(bat_level)
+    bat_bg          = _battery_bg(bat_level)
+    link_display    = f"{link_speed} Mbps" if link_speed is not None else "—"
+
+    installs_count  = d.get("installs_count", 0)
+
+    battery_data    = d.get("battery_telemetry") or []
+    temp_data       = d.get("temp_telemetry") or []
+    commands        = d.get("commands") or []
+
+    # Build chart data JSON for injection
+    bat_labels  = json.dumps([p["x"] for p in battery_data])
+    bat_values  = json.dumps([p["y"] for p in battery_data])
+    temp_labels = json.dumps([p["x"] for p in temp_data])
+    temp_values = json.dumps([p["y"] for p in temp_data])
+
+    # Commands table rows
+    cmd_rows = ""
+    for cmd in commands:
+        state_cls  = _cmd_state_class(cmd.get("state", ""))
+        cmd_rows += (
+            f'<tr>'
+            f'<td class="td-date muted">{cmd.get("date","")}</td>'
+            f'<td class="td-cmd"><code>{cmd.get("command","")}</code></td>'
+            f'<td class="td-by muted">{cmd.get("issued_by","")}</td>'
+            f'<td><span class="cmd-badge {state_cls}">{cmd.get("state","")}</span></td>'
+            f'</tr>'
+        )
+    if not cmd_rows:
+        cmd_rows = '<tr><td colspan="4" class="muted td-empty">No recent commands</td></tr>'
+
+    # No-data placeholders for charts
+    bat_chart_empty = "" if battery_data else '<div class="chart-empty muted">No telemetry data available</div>'
+    temp_chart_empty = "" if temp_data else '<div class="chart-empty muted">No telemetry data available</div>'
+    bat_canvas_style = "" if battery_data else 'style="display:none"'
+    temp_canvas_style = "" if temp_data else 'style="display:none"'
+
+    # Alert banner if battery critical
+    alert_html = ""
+    if bat_level is not None and bat_level <= 10:
+        alert_html = f'''
+        <div class="alert alert-critical">
+          <span class="alert-icon">⚠</span>
+          Battery critically low ({bat_level}%) — device may be offline or about to die.
+        </div>'''
+
+    # android version from api level
+    api_to_android = {
+        33: "13", 32: "12L", 31: "12", 30: "11", 29: "10",
+        28: "9 Pie", 27: "8.1", 26: "8.0",
+    }
+    android_ver = api_to_android.get(api_level, f"API {api_level}")
+
+    html = f"""<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Device Report — {name}</title>
+  <script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.4/dist/chart.umd.min.js"></script>
+  <style>
+    *, *::before, *::after {{ box-sizing: border-box; margin: 0; padding: 0; }}
+    body {{
+      background: #0a0f1e;
+      color: #e2e8f0;
+      font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+      font-size: 14px;
+      line-height: 1.5;
+      padding: 2rem;
+      min-height: 100vh;
+    }}
+    a {{ color: #38bdf8; text-decoration: none; }}
+
+    /* ── Layout ── */
+    .page {{ max-width: 1200px; margin: 0 auto; }}
+
+    /* ── Header ── */
+    .header {{
+      display: flex; justify-content: space-between; align-items: flex-start;
+      margin-bottom: 1.75rem; flex-wrap: wrap; gap: 1rem;
+    }}
+    .header-left h1 {{
+      font-size: 2rem; font-weight: 700; letter-spacing: -0.02em;
+      background: linear-gradient(135deg, #e2e8f0 0%, #94a3b8 100%);
+      -webkit-background-clip: text; -webkit-text-fill-color: transparent;
+    }}
+    .header-left .sub {{
+      color: #64748b; margin-top: 0.35rem; font-size: 0.85rem;
+    }}
+    .header-right {{ text-align: right; }}
+    .header-right .gen-time {{ color: #475569; font-size: 0.8rem; margin-top: 0.35rem; }}
+
+    /* ── Badges ── */
+    .badge-green, .badge-red, .badge-muted {{
+      display: inline-block; padding: 0.25rem 0.75rem;
+      border-radius: 9999px; font-size: 0.75rem; font-weight: 600;
+      letter-spacing: 0.05em;
+    }}
+    .badge-green  {{ background: rgba(74,222,128,0.15); color: #4ade80; border: 1px solid rgba(74,222,128,0.3); }}
+    .badge-red    {{ background: rgba(248,113,113,0.15); color: #f87171; border: 1px solid rgba(248,113,113,0.3); }}
+    .badge-muted  {{ background: rgba(148,163,184,0.1); color: #94a3b8; border: 1px solid rgba(148,163,184,0.2); }}
+
+    /* ── Alert ── */
+    .alert {{
+      display: flex; align-items: center; gap: 0.75rem;
+      padding: 0.75rem 1rem; border-radius: 0.5rem;
+      margin-bottom: 1.5rem; font-size: 0.85rem; font-weight: 500;
+    }}
+    .alert-critical {{
+      background: rgba(248,113,113,0.12); border: 1px solid rgba(248,113,113,0.3); color: #fca5a5;
+    }}
+    .alert-icon {{ font-size: 1rem; }}
+
+    /* ── Cards ── */
+    .cards-grid {{
+      display: grid;
+      grid-template-columns: repeat(5, 1fr);
+      gap: 1rem;
+      margin-bottom: 1.5rem;
+    }}
+    @media (max-width: 900px)  {{ .cards-grid {{ grid-template-columns: repeat(3, 1fr); }} }}
+    @media (max-width: 600px)  {{ .cards-grid {{ grid-template-columns: repeat(2, 1fr); }} }}
+
+    .card {{
+      background: #131929; border: 1px solid #1e2d45;
+      border-radius: 0.75rem; padding: 1.1rem 1.25rem;
+      position: relative; overflow: hidden;
+    }}
+    .card-label {{
+      font-size: 0.7rem; font-weight: 600; letter-spacing: 0.08em;
+      text-transform: uppercase; color: #475569; margin-bottom: 0.5rem;
+    }}
+    .card-value {{
+      font-size: 1.75rem; font-weight: 700; letter-spacing: -0.02em;
+      line-height: 1;
+    }}
+    .card-sub {{
+      font-size: 0.75rem; color: #475569; margin-top: 0.35rem;
+    }}
+    .card-icon {{
+      position: absolute; top: 1rem; right: 1rem;
+      font-size: 1.5rem; opacity: 0.15;
+    }}
+
+    /* battery card progress bar */
+    .bat-bar-wrap {{
+      background: #1e293b; border-radius: 9999px; height: 4px;
+      margin-top: 0.75rem; overflow: hidden;
+    }}
+    .bat-bar-fill {{
+      height: 100%; border-radius: 9999px;
+      transition: width 0.5s ease;
+    }}
+
+    /* signal dots */
+    .dot-filled {{ color: #38bdf8; }}
+    .dot-empty  {{ color: #1e293b; }}
+
+    /* ── Charts row ── */
+    .charts-row {{
+      display: grid; grid-template-columns: 3fr 2fr;
+      gap: 1rem; margin-bottom: 1.5rem;
+    }}
+    @media (max-width: 700px) {{ .charts-row {{ grid-template-columns: 1fr; }} }}
+
+    .chart-card {{
+      background: #131929; border: 1px solid #1e2d45;
+      border-radius: 0.75rem; padding: 1.25rem;
+    }}
+    .chart-title {{
+      font-size: 0.75rem; font-weight: 600; letter-spacing: 0.06em;
+      text-transform: uppercase; color: #475569; margin-bottom: 1rem;
+    }}
+    .chart-wrap {{ position: relative; height: 200px; }}
+    .chart-empty {{
+      display: flex; align-items: center; justify-content: center;
+      height: 200px; font-size: 0.85rem;
+    }}
+
+    /* ── Info grid (below charts) ── */
+    .info-grid {{
+      display: grid; grid-template-columns: repeat(2, 1fr);
+      gap: 1rem; margin-bottom: 1.5rem;
+    }}
+    @media (max-width: 600px) {{ .info-grid {{ grid-template-columns: 1fr; }} }}
+
+    /* ── Commands table ── */
+    .commands-card {{
+      background: #131929; border: 1px solid #1e2d45;
+      border-radius: 0.75rem; padding: 1.25rem;
+    }}
+    .section-title {{
+      font-size: 0.75rem; font-weight: 600; letter-spacing: 0.06em;
+      text-transform: uppercase; color: #475569; margin-bottom: 1rem;
+    }}
+    table {{ width: 100%; border-collapse: collapse; }}
+    th {{
+      text-align: left; font-size: 0.7rem; font-weight: 600;
+      letter-spacing: 0.06em; text-transform: uppercase; color: #334155;
+      padding: 0 0.75rem 0.6rem;
+      border-bottom: 1px solid #1e2d45;
+    }}
+    td {{
+      padding: 0.6rem 0.75rem; border-bottom: 1px solid #0f1929;
+      font-size: 0.83rem; vertical-align: middle;
+    }}
+    tr:last-child td {{ border-bottom: none; }}
+    code {{
+      font-family: "SF Mono", "Fira Code", Menlo, monospace;
+      font-size: 0.78rem; color: #e2e8f0;
+    }}
+    .td-date  {{ color: #475569; white-space: nowrap; }}
+    .td-empty {{ text-align: center; padding: 2rem; }}
+
+    .cmd-badge {{
+      display: inline-block; padding: 0.15rem 0.5rem;
+      border-radius: 4px; font-size: 0.7rem; font-weight: 600;
+      letter-spacing: 0.04em;
+    }}
+    .cmd-success {{ background: rgba(74,222,128,0.12); color: #4ade80; }}
+    .cmd-fail    {{ background: rgba(248,113,113,0.12); color: #f87171; }}
+    .cmd-neutral {{ background: rgba(148,163,184,0.1); color: #94a3b8; }}
+
+    /* ── Device info card ── */
+    .kv-list {{ list-style: none; }}
+    .kv-list li {{
+      display: flex; justify-content: space-between; align-items: center;
+      padding: 0.45rem 0; border-bottom: 1px solid #0f1929;
+      font-size: 0.83rem;
+    }}
+    .kv-list li:last-child {{ border-bottom: none; }}
+    .kv-key {{ color: #475569; }}
+    .kv-val {{ font-weight: 500; text-align: right; max-width: 60%; word-break: break-all; }}
+
+    /* ── Footer ── */
+    .footer {{
+      margin-top: 2rem; padding-top: 1rem; border-top: 1px solid #1e2d45;
+      color: #1e293b; font-size: 0.75rem; text-align: center;
+    }}
+
+    .muted {{ color: #475569; }}
+  </style>
+</head>
+<body>
+<div class="page">
+
+  <!-- Header -->
+  <div class="header">
+    <div class="header-left">
+      <h1>{name}</h1>
+      <div class="sub">{hw_name} &nbsp;·&nbsp; Android {android_ver} &nbsp;·&nbsp; GMS: {is_gms}</div>
+      <div class="sub" style="margin-top:0.2rem; word-break:break-all; font-size:0.78rem; color:#334155">{dev_id}</div>
+    </div>
+    <div class="header-right">
+      {_state_badge(state_val)}
+      <div class="gen-time">Generated {generated}</div>
+    </div>
+  </div>
+
+  {alert_html}
+
+  <!-- Metric cards -->
+  <div class="cards-grid">
+
+    <!-- Battery -->
+    <div class="card" style="background:{bat_bg}; border-color: {bat_color}33;">
+      <div class="card-label">Battery</div>
+      <div class="card-value" style="color:{bat_color}">{bat_pct_display}</div>
+      <div class="card-sub">{bat_temp_display} temperature</div>
+      <div class="bat-bar-wrap">
+        <div class="bat-bar-fill" style="width:{bat_pct_val}%; background:{bat_color}"></div>
+      </div>
+    </div>
+
+    <!-- Temperature -->
+    <div class="card">
+      <div class="card-label">Temperature</div>
+      <div class="card-value" style="color:#38bdf8">{bat_temp_display}</div>
+      <div class="card-sub">device body temp</div>
+      <div class="card-icon">🌡</div>
+    </div>
+
+    <!-- Storage -->
+    <div class="card">
+      <div class="card-label">Free Storage</div>
+      <div class="card-value" style="color:#a78bfa">{_mb_display(storage_mb)}</div>
+      <div class="card-sub">available space</div>
+      <div class="card-icon">💾</div>
+    </div>
+
+    <!-- RAM -->
+    <div class="card">
+      <div class="card-label">Free RAM</div>
+      <div class="card-value" style="color:#67e8f9">{_mb_display(ram_mb)}</div>
+      <div class="card-sub">available memory</div>
+      <div class="card-icon">⚡</div>
+    </div>
+
+    <!-- WiFi -->
+    <div class="card">
+      <div class="card-label">WiFi</div>
+      <div class="card-value" style="font-size:1.1rem; padding-top:0.25rem">
+        {_signal_dots(sig_str)}
+      </div>
+      <div class="card-sub">{link_display} link speed</div>
+      <div class="card-icon">📶</div>
+    </div>
+
+  </div>
+
+  <!-- Charts -->
+  <div class="charts-row">
+    <div class="chart-card">
+      <div class="chart-title">Battery Level — 30 Day Trend</div>
+      <div class="chart-wrap">
+        {bat_chart_empty}
+        <canvas id="batteryChart" {bat_canvas_style}></canvas>
+      </div>
+    </div>
+    <div class="chart-card">
+      <div class="chart-title">Temperature — 30 Day Trend</div>
+      <div class="chart-wrap">
+        {temp_chart_empty}
+        <canvas id="tempChart" {temp_canvas_style}></canvas>
+      </div>
+    </div>
+  </div>
+
+  <!-- Info + Commands -->
+  <div class="info-grid">
+
+    <!-- Device info -->
+    <div class="card">
+      <div class="section-title">Device Info</div>
+      <ul class="kv-list">
+        <li><span class="kv-key">Hardware</span><span class="kv-val">{hw_name}</span></li>
+        <li><span class="kv-key">Android</span><span class="kv-val">{android_ver} (API {api_level})</span></li>
+        <li><span class="kv-key">GMS</span><span class="kv-val">{is_gms}</span></li>
+        <li><span class="kv-key">State</span><span class="kv-val">{state_val}</span></li>
+        <li><span class="kv-key">Installed Apps</span><span class="kv-val">{installs_count}</span></li>
+        <li><span class="kv-key">Device ID</span>
+          <span class="kv-val" style="font-family:monospace; font-size:0.72rem">{dev_id}</span>
+        </li>
+      </ul>
+    </div>
+
+    <!-- Recent commands -->
+    <div class="commands-card">
+      <div class="section-title">Recent Commands</div>
+      <table>
+        <thead>
+          <tr>
+            <th>Date</th>
+            <th>Command</th>
+            <th>Issued By</th>
+            <th>State</th>
+          </tr>
+        </thead>
+        <tbody>
+          {cmd_rows}
+        </tbody>
+      </table>
+    </div>
+
+  </div>
+
+  <div class="footer">espercli device report &nbsp;·&nbsp; {generated}</div>
+
+</div><!-- /page -->
+
+<script>
+  // ── Injected data ──────────────────────────────────────────────────────
+  const batLabels  = {bat_labels};
+  const batValues  = {bat_values};
+  const tempLabels = {temp_labels};
+  const tempValues = {temp_values};
+  const batColor   = "{bat_color}";
+
+  // ── Helper: gradient fill ──────────────────────────────────────────────
+  function makeGradient(ctx, color) {{
+    const g = ctx.createLinearGradient(0, 0, 0, 200);
+    g.addColorStop(0, color + "55");
+    g.addColorStop(1, color + "00");
+    return g;
+  }}
+
+  // ── Battery chart ──────────────────────────────────────────────────────
+  if (batLabels.length > 0) {{
+    const batCtx = document.getElementById("batteryChart").getContext("2d");
+    new Chart(batCtx, {{
+      type: "line",
+      data: {{
+        labels: batLabels,
+        datasets: [{{
+          label: "Battery %",
+          data: batValues,
+          borderColor: batColor,
+          backgroundColor: makeGradient(batCtx, batColor),
+          borderWidth: 2,
+          pointRadius: 3,
+          pointBackgroundColor: batColor,
+          tension: 0.35,
+          fill: true,
+        }}]
+      }},
+      options: {{
+        responsive: true,
+        maintainAspectRatio: false,
+        scales: {{
+          x: {{
+            grid: {{ color: "#1e2d45" }},
+            ticks: {{ color: "#475569", font: {{ size: 10 }}, maxTicksLimit: 8 }}
+          }},
+          y: {{
+            min: 0, max: 100,
+            grid: {{ color: "#1e2d45" }},
+            ticks: {{ color: "#475569", font: {{ size: 10 }}, callback: v => v + "%" }}
+          }}
+        }},
+        plugins: {{
+          legend: {{ display: false }},
+          tooltip: {{
+            backgroundColor: "#1e293b",
+            borderColor: "#334155",
+            borderWidth: 1,
+            titleColor: "#94a3b8",
+            bodyColor: "#e2e8f0",
+            callbacks: {{ label: ctx => " " + ctx.parsed.y.toFixed(1) + "%" }}
+          }}
+        }}
+      }}
+    }});
+  }}
+
+  // ── Temperature chart ──────────────────────────────────────────────────
+  if (tempLabels.length > 0) {{
+    const tempCtx = document.getElementById("tempChart").getContext("2d");
+    new Chart(tempCtx, {{
+      type: "line",
+      data: {{
+        labels: tempLabels,
+        datasets: [{{
+          label: "Temp °C",
+          data: tempValues,
+          borderColor: "#38bdf8",
+          backgroundColor: makeGradient(tempCtx, "#38bdf8"),
+          borderWidth: 2,
+          pointRadius: 3,
+          pointBackgroundColor: "#38bdf8",
+          tension: 0.35,
+          fill: true,
+        }}]
+      }},
+      options: {{
+        responsive: true,
+        maintainAspectRatio: false,
+        scales: {{
+          x: {{
+            grid: {{ color: "#1e2d45" }},
+            ticks: {{ color: "#475569", font: {{ size: 10 }}, maxTicksLimit: 6 }}
+          }},
+          y: {{
+            grid: {{ color: "#1e2d45" }},
+            ticks: {{ color: "#475569", font: {{ size: 10 }}, callback: v => v + "°" }}
+          }}
+        }},
+        plugins: {{
+          legend: {{ display: false }},
+          tooltip: {{
+            backgroundColor: "#1e293b",
+            borderColor: "#334155",
+            borderWidth: 1,
+            titleColor: "#94a3b8",
+            bodyColor: "#e2e8f0",
+            callbacks: {{ label: ctx => " " + ctx.parsed.y.toFixed(1) + "°C" }}
+          }}
+        }}
+      }}
+    }});
+  }}
+</script>
+</body>
+</html>"""
+
+    return html

--- a/esper/cli/report_html.py
+++ b/esper/cli/report_html.py
@@ -6,6 +6,7 @@ Chart.js from a CDN) that can be opened in any browser.
 """
 from __future__ import annotations
 
+import html as _html
 import json
 
 # ---------------------------------------------------------------------------
@@ -84,10 +85,10 @@ def generate_html(d: dict) -> str:
       temp_telemetry (list of {x,y}), commands (list of dicts),
       installs_count (int)
     """
-    name        = d.get("name", "Unknown Device")
-    hw_name     = d.get("hardware_name", "—")
-    dev_id      = d.get("device_id", "—")
-    state_val   = d.get("state", "UNKNOWN")
+    name        = _html.escape(str(d.get("name", "Unknown Device")))
+    hw_name     = _html.escape(str(d.get("hardware_name", "—")))
+    dev_id      = _html.escape(str(d.get("device_id", "—")))
+    state_val   = _html.escape(str(d.get("state", "UNKNOWN")))
     api_level   = d.get("api_level", "—")
     is_gms      = "Yes" if d.get("is_gms") else "No"
     generated   = d.get("generated_at", "")
@@ -122,13 +123,17 @@ def generate_html(d: dict) -> str:
     # Commands table rows
     cmd_rows = ""
     for cmd in commands:
-        state_cls  = _cmd_state_class(cmd.get("state", ""))
+        cmd_date    = _html.escape(str(cmd.get("date", "")))
+        cmd_command = _html.escape(str(cmd.get("command", "")))
+        cmd_by      = _html.escape(str(cmd.get("issued_by", "")))
+        cmd_state   = _html.escape(str(cmd.get("state", "")))
+        state_cls   = _cmd_state_class(cmd_state)
         cmd_rows += (
             f'<tr>'
-            f'<td class="td-date muted">{cmd.get("date","")}</td>'
-            f'<td class="td-cmd"><code>{cmd.get("command","")}</code></td>'
-            f'<td class="td-by muted">{cmd.get("issued_by","")}</td>'
-            f'<td><span class="cmd-badge {state_cls}">{cmd.get("state","")}</span></td>'
+            f'<td class="td-date muted">{cmd_date}</td>'
+            f'<td class="td-cmd"><code>{cmd_command}</code></td>'
+            f'<td class="td-by muted">{cmd_by}</td>'
+            f'<td><span class="cmd-badge {state_cls}">{cmd_state}</span></td>'
             f'</tr>'
         )
     if not cmd_rows:

--- a/esper/cli/retry.py
+++ b/esper/cli/retry.py
@@ -1,0 +1,73 @@
+"""
+Retry utility for transient API failures.
+
+Usage::
+
+    from esper.cli.retry import with_retry
+    from esperclient.rest import ApiException
+
+    @with_retry(retries=3, backoff=1.0, exceptions=(ApiException,))
+    def call_api():
+        return client.get_all_devices(enterprise_id)
+
+The decorator retries only on *transient* failures:
+
+* The exception has a ``status`` attribute ≥ 500 (server-side error), or
+* The exception is a ``ConnectionError`` / ``TimeoutError`` / ``OSError``.
+
+Back-off is exponential: ``backoff * 2^attempt`` seconds between tries.
+"""
+from __future__ import annotations
+
+import functools
+import logging
+import time
+from typing import Callable, Tuple, Type
+
+log = logging.getLogger("espercli")
+
+
+def with_retry(
+    retries: int = 3,
+    backoff: float = 1.0,
+    exceptions: Tuple[Type[Exception], ...] = (Exception,),
+) -> Callable:
+    """
+    Decorator factory.  Returns a decorator that wraps *func* with retry
+    logic.
+
+    Parameters
+    ----------
+    retries:
+        Maximum number of total attempts (default 3).
+    backoff:
+        Base wait time in seconds (doubles each attempt, default 1.0).
+    exceptions:
+        Only catch these exception types (default ``(Exception,)``).
+    """
+    def decorator(func: Callable) -> Callable:
+        @functools.wraps(func)
+        def wrapper(*args, **kwargs):
+            last_exc: Exception | None = None
+            for attempt in range(retries):
+                try:
+                    return func(*args, **kwargs)
+                except exceptions as exc:
+                    last_exc = exc
+                    # Only retry on genuinely transient failures
+                    transient = (
+                        isinstance(exc, (ConnectionError, TimeoutError, OSError))
+                        or (hasattr(exc, "status") and isinstance(exc.status, int) and exc.status >= 500)
+                    )
+                    if not transient or attempt >= retries - 1:
+                        raise
+                    wait = backoff * (2 ** attempt)
+                    log.debug(
+                        "[retry] %s attempt %d/%d failed (%s); retrying in %.1fs…",
+                        func.__name__, attempt + 1, retries, exc, wait,
+                    )
+                    time.sleep(wait)
+            raise last_exc  # pragma: no cover
+
+        return wrapper
+    return decorator

--- a/esper/cli/secureadb.py
+++ b/esper/cli/secureadb.py
@@ -1,0 +1,170 @@
+"""
+Secure ADB commands — replaces esper/controllers/secureadb/secureadb.py.
+`espercli secureadb connect`
+"""
+import signal
+import socket
+import ssl
+from typing import Optional
+
+import typer
+from esperclient.rest import ApiException
+
+from esper.cli.output import render
+from esper.cli.state import state, validate_creds
+from esper.controllers.enums import OutputFormat
+from esper.ext.api_client import APIClient
+from esper.ext.certs import cleanup_certs, create_self_signed_cert, save_device_certificate
+from esper.ext.db_wrapper import DBWrapper
+from esper.ext.relay import Relay
+from esper.ext.remoteadb_api import (
+    initiate_remoteadb_connection, fetch_device_certificate, fetch_relay_endpoint,
+    RemoteADBError,
+)
+
+app = typer.Typer(help="Setup Secure ADB connection to device")
+
+
+class SecureADBWorkflowError(Exception):
+    pass
+
+
+def _fetch_device_by_name(db: DBWrapper, name: str) -> str:
+    """Fetch device ID by device name."""
+    device_client = APIClient(db.get_configure()).get_device_api_client()
+    enterprise_id = db.get_enterprise_id()
+    search_response = device_client.get_all_devices(enterprise_id, limit=1, offset=0, name=name)
+    if not search_response.results:
+        raise SecureADBWorkflowError(f"Device does not exist with name {name}")
+    return search_response.results[0].id
+
+
+def _setup_ssl_connection(host: str, port: int,
+                          client_cert: str, client_key: str,
+                          device_cert: str) -> ssl.SSLSocket:
+    """Create a mutual-TLS SSL connection to the relay endpoint."""
+    state.log.debug("[remoteadb-connect] Starting SSL Connection setup")
+    sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    sock.connect((host, port))
+    state.log.debug("[remoteadb-connect] Connected to TCP endpoint")
+
+    context = ssl.SSLContext(ssl.PROTOCOL_TLS_CLIENT)
+    context.verify_mode = ssl.CERT_REQUIRED
+    context.check_hostname = False
+    context.load_verify_locations(cafile=device_cert)
+    context.load_cert_chain(certfile=client_cert, keyfile=client_key)
+
+    secure_sock = context.wrap_socket(sock, server_side=False)
+    state.log.debug(f"[remoteadb-connect] Peer Certificate -> {secure_sock.getpeercert()}")
+    return secure_sock
+
+
+# ---------------------------------------------------------------------------
+# Commands
+# ---------------------------------------------------------------------------
+
+@app.command("connect")
+def secureadb_connect(
+    device_name: Optional[str] = typer.Option(
+        None, "--device", "-d", help="Device name"
+    ),
+):
+    """Setup and connect securely via Remote ADB to a device."""
+    validate_creds()
+    db = DBWrapper(state.creds)
+    environment = db.get_configure().get("environment")
+    enterprise_id = db.get_enterprise_id()
+    api_key = db.get_configure().get("api_key")
+
+    # Remove older certs and create new ones
+    cleanup_certs(state)
+    create_self_signed_cert(local_cert=state.local_cert, local_key=state.local_key)
+
+    relay = None
+    try:
+        # Resolve device ID
+        if device_name:
+            device_id = _fetch_device_by_name(db, device_name)
+            state.log.debug(f"Device Name: {device_name}. Device ID: {device_id}")
+        elif db.get_device():
+            device_id = db.get_device().get("id")
+        else:
+            state.log.error("[remoteadb-connect] Device not specified!")
+            render("ERROR: No device specified. Use --device or set an active device.")
+            raise typer.Exit(1)
+
+        render("\nInitiating Remote ADB Session. This may take a few seconds...\n")
+
+        remoteadb_id = initiate_remoteadb_connection(
+            environment=environment,
+            enterprise_id=enterprise_id,
+            device_id=device_id,
+            api_key=api_key,
+            client_cert_path=state.local_cert,
+            log=state.log,
+        )
+
+        relay_ip, relay_port = fetch_relay_endpoint(
+            environment=environment,
+            enterprise_id=enterprise_id,
+            device_id=device_id,
+            remoteadb_id=remoteadb_id,
+            api_key=api_key,
+            log=state.log,
+        )
+
+        device_cert_contents = fetch_device_certificate(
+            environment=environment,
+            enterprise_id=enterprise_id,
+            device_id=device_id,
+            remoteadb_id=remoteadb_id,
+            api_key=api_key,
+            log=state.log,
+        )
+
+        save_device_certificate(state.device_cert, device_cert_contents)
+
+        secure_sock = _setup_ssl_connection(
+            host=relay_ip,
+            port=relay_port,
+            client_cert=state.local_cert,
+            client_key=state.local_key,
+            device_cert=state.device_cert,
+        )
+
+        relay = Relay(relay_conn=secure_sock, relay_addr=secure_sock.getsockname(), log=state.log)
+        listener_ip, listener_port = relay.get_listener_address()
+
+        title = "Secure ADB Client"
+        table = [
+            {title: f"Please connect ADB client to the following endpoint: {listener_ip} : {listener_port}"},
+            {title: f"If adb-tools is installed, please run:\n adb connect {listener_ip}:{listener_port}"},
+            {title: "Press Ctrl+C to quit!"},
+        ]
+        render(table, format=OutputFormat.TABULATED.value, headers="keys", tablefmt="plain")
+
+        state.log.debug("[remoteadb-connect] Starting Client Mediator")
+        relay.accept_connection()
+        relay.start_relay()
+
+    except (SecureADBWorkflowError, RemoteADBError) as exc:
+        state.log.error(f"[remoteadb-connect] {exc}")
+        render("[ERROR] Issue in reaching Esper API Service for connection negotiation!")
+
+    except KeyboardInterrupt:
+        render("Quitting application...")
+
+    except Exception as exc:
+        state.log.error(f"Failed to establish Secure ADB connection to device: {device_name}")
+        state.log.debug(f"Exception: {exc}")
+
+    finally:
+        if relay is not None:
+            relay.stop_relay()
+            metrics = relay.gather_metrics()
+            relay.cleanup_connections()
+
+            if metrics.get("started") and metrics.get("stopped"):
+                render(f"\nSession Duration: {metrics['stopped'] - metrics['started']}\n")
+            if metrics.get("bytes"):
+                render(f"\nTotal Data streamed: {metrics['bytes'] / 1024.0} KB\n")

--- a/esper/cli/stage.py
+++ b/esper/cli/stage.py
@@ -1,0 +1,196 @@
+"""
+Pipeline Stage commands — nested under `pipeline`.
+`espercli pipeline stage create/edit/show/remove`
+"""
+from typing import Optional
+
+import typer
+
+from esper.cli.output import render
+from esper.cli.state import state, validate_creds
+from esper.controllers.enums import OutputFormat
+from esper.ext.db_wrapper import DBWrapper
+from esper.ext.pipeline_api import (
+    get_stage_url, create_stage, edit_stage, list_stages, delete_api,
+    APIException, render_single_dict,
+)
+
+app = typer.Typer(help="Pipeline Stage commands")
+
+
+# ---------------------------------------------------------------------------
+# Commands
+# ---------------------------------------------------------------------------
+
+@app.command("create")
+def stage_create(
+    pipeline_id: Optional[str] = typer.Option(None, "--pipeline-id", "-p", help="Pipeline ID"),
+    name: Optional[str] = typer.Option(None, "--name", "-n", help="Stage name"),
+    order: Optional[int] = typer.Option(None, "--order", "-o", help="Stage ordering (unique within pipeline)"),
+    desc: Optional[str] = typer.Option(None, "--desc", help="Stage description"),
+):
+    """Add a Stage to a Pipeline."""
+    validate_creds()
+    db = DBWrapper(state.creds)
+    environment = db.get_configure().get("environment")
+    enterprise_id = db.get_enterprise_id()
+    api_key = db.get_configure().get("api_key")
+
+    if not pipeline_id:
+        pipeline_id = typer.prompt("Enter the Pipeline ID")
+    if not name:
+        name = typer.prompt("Name of the Stage")
+    if order is None:
+        order = int(typer.prompt("Order of this Stage"))
+    if desc is None:
+        desc = typer.prompt("Description for this Stage [optional]", default="")
+
+    url = get_stage_url(environment, enterprise_id, pipeline_id)
+    try:
+        response = create_stage(url, api_key, name, order, desc)
+    except APIException:
+        render("ERROR in connecting to Environment!")
+        raise typer.Exit(1)
+
+    if not response.ok:
+        _handle_stage_error(response, "stage-create")
+        raise typer.Exit(1)
+
+    data = render_single_dict(response.json())
+    render("Added Stage to Pipeline Successfully! Details:")
+    render(data, format=OutputFormat.TABULATED.value, headers="keys", tablefmt="plain")
+
+
+@app.command("edit")
+def stage_edit(
+    pipeline_id: Optional[str] = typer.Option(None, "--pipeline-id", "-p", help="Pipeline ID"),
+    stage_id: Optional[str] = typer.Option(None, "--stage-id", "-s", help="Stage ID"),
+    name: Optional[str] = typer.Option(None, "--name", "-n", help="New stage name"),
+    order: Optional[int] = typer.Option(None, "--order", "-o", help="New stage ordering"),
+    desc: Optional[str] = typer.Option(None, "--desc", help="New stage description"),
+):
+    """Edit a Stage."""
+    validate_creds()
+    db = DBWrapper(state.creds)
+    environment = db.get_configure().get("environment")
+    enterprise_id = db.get_enterprise_id()
+    api_key = db.get_configure().get("api_key")
+
+    if not pipeline_id:
+        pipeline_id = typer.prompt("Enter the Pipeline ID")
+    if not stage_id:
+        stage_id = typer.prompt("Enter the Stage ID")
+    if name is None:
+        name = typer.prompt("Change the name of the Stage", default="")
+    if desc is None:
+        desc = typer.prompt("Change the description [optional]", default="")
+    if order is None:
+        order_str = typer.prompt("Change the ordering [optional]", default="")
+        order = int(order_str) if order_str else None
+
+    url = get_stage_url(environment, enterprise_id, pipeline_id=pipeline_id, stage_id=stage_id)
+    try:
+        response = edit_stage(url, api_key, name, order, desc)
+    except APIException:
+        render("ERROR in connecting to Environment!")
+        raise typer.Exit(1)
+
+    if not response.ok:
+        _handle_stage_error(response, "stage-edit")
+        raise typer.Exit(1)
+
+    data = render_single_dict(response.json())
+    render("Edited Stage for this Pipeline Successfully! Details:")
+    render(data, format=OutputFormat.TABULATED.value, headers="keys", tablefmt="plain")
+
+
+@app.command("show")
+def stage_show(
+    pipeline_id: Optional[str] = typer.Option(None, "--pipeline-id", "-p", help="Pipeline ID"),
+):
+    """List all Stages in a Pipeline."""
+    validate_creds()
+    db = DBWrapper(state.creds)
+    environment = db.get_configure().get("environment")
+    enterprise_id = db.get_enterprise_id()
+    api_key = db.get_configure().get("api_key")
+
+    if not pipeline_id:
+        pipeline_id = typer.prompt("Enter the Pipeline ID")
+
+    url = get_stage_url(environment, enterprise_id, pipeline_id=pipeline_id)
+    try:
+        response = list_stages(url, api_key)
+    except APIException:
+        render("ERROR in connecting to Environment!")
+        raise typer.Exit(1)
+
+    if not response.ok:
+        _handle_stage_error(response, "stage-show")
+        raise typer.Exit(1)
+
+    data = response.json().get("results") or []
+    render_data = [
+        {
+            "ID": s.get("id"),
+            "NAME": s.get("name"),
+            "DESCRIPTION": s.get("description"),
+            "ORDERING": s.get("ordering"),
+            "OPERATIONS": len(s.get("operations", [])),
+            "VERSION": s.get("version"),
+        }
+        for s in data
+    ]
+
+    render("Listing Stages for the Pipeline! Details:")
+    render(render_data, format=OutputFormat.TABULATED.value, headers="keys", tablefmt="plain")
+
+
+@app.command("remove")
+def stage_remove(
+    pipeline_id: Optional[str] = typer.Option(None, "--pipeline-id", "-p", help="Pipeline ID"),
+    stage_id: Optional[str] = typer.Option(None, "--stage-id", "-s", help="Stage ID"),
+):
+    """Remove a Stage from a Pipeline."""
+    validate_creds()
+    db = DBWrapper(state.creds)
+    environment = db.get_configure().get("environment")
+    enterprise_id = db.get_enterprise_id()
+    api_key = db.get_configure().get("api_key")
+
+    if not pipeline_id:
+        pipeline_id = typer.prompt("Enter the Pipeline ID")
+    if not stage_id:
+        stage_id = typer.prompt("Enter the Stage ID")
+
+    url = get_stage_url(environment, enterprise_id, pipeline_id=pipeline_id, stage_id=stage_id)
+    try:
+        response = delete_api(url, api_key)
+    except APIException:
+        render("ERROR in connecting to Environment!")
+        raise typer.Exit(1)
+
+    if not response.ok:
+        _handle_stage_error(response, "stage-remove")
+        raise typer.Exit(1)
+
+    render("Removed Stage for this Pipeline Successfully!")
+
+
+# ---------------------------------------------------------------------------
+# Internal
+# ---------------------------------------------------------------------------
+
+def _handle_stage_error(response, tag: str):
+    state.log.debug(f"[{tag}] Response not OK. Status: {response.status_code}")
+    if response.status_code == 400:
+        errors = response.json().get("meta", {}).get("non_field_errors")
+        if errors:
+            state.log.error(f"Validation Error: {errors}")
+        field_errors = response.json().get("errors")
+        if field_errors:
+            state.log.error(f"Validation Error: {field_errors}")
+    elif response.status_code == 404:
+        state.log.error("Stage URL not found!")
+    elif response.status_code == 500:
+        state.log.error(f"Internal Server Error! {response.json()}")

--- a/esper/cli/state.py
+++ b/esper/cli/state.py
@@ -5,6 +5,7 @@ All CLI modules import `state` from here instead of using `self.app`.
 import json
 import logging
 import os
+import stat
 import sys
 from pathlib import Path
 
@@ -13,8 +14,17 @@ from tinydb import TinyDB
 
 from esper.ext.db_wrapper import DBWrapper
 
-CREDS_FILE = os.path.expanduser("~/.esper/db/creds.json")
-CERTS_FOLDER = os.path.expanduser("~/.esper/certs")
+# Paths can be overridden via environment variables so that test suites and
+# non-standard deployments can point to a different credential store without
+# editing source code.
+CREDS_FILE = os.environ.get(
+    "ESPER_CREDS_FILE",
+    os.path.expanduser("~/.esper/db/creds.json"),
+)
+CERTS_FOLDER = os.environ.get(
+    "ESPER_CERTS_DIR",
+    os.path.expanduser("~/.esper/certs"),
+)
 
 
 class EsperState:
@@ -25,9 +35,9 @@ class EsperState:
         self.debug = False
 
         # Cert paths (used by secureadb)
-        self.local_key = os.path.expanduser("~/.esper/certs/local.key")
-        self.local_cert = os.path.expanduser("~/.esper/certs/local.pem")
-        self.device_cert = os.path.expanduser("~/.esper/certs/device.pem")
+        self.local_key = os.path.join(CERTS_FOLDER, "local.key")
+        self.local_cert = os.path.join(CERTS_FOLDER, "local.pem")
+        self.device_cert = os.path.join(CERTS_FOLDER, "device.pem")
         self.certs_path = CERTS_FOLDER
 
         # Logger
@@ -39,11 +49,30 @@ class EsperState:
 
     @property
     def creds(self):
-        """Lazy-initialise TinyDB, creating parent dirs as needed."""
+        """Lazy-initialise TinyDB, creating parent dirs as needed.
+
+        The credentials directory is created with mode 0o700 (owner-only) and
+        the database file is locked down to 0o600 after first write so that
+        the API key is never readable by other users on a shared system.
+        """
         if self._creds is None:
             creds_path = Path(CREDS_FILE)
-            creds_path.parent.mkdir(parents=True, exist_ok=True)
+            creds_dir = creds_path.parent
+
+            # Create the directory with restrictive permissions.
+            creds_dir.mkdir(parents=True, exist_ok=True)
+            try:
+                os.chmod(creds_dir, stat.S_IRWXU)  # 0o700
+            except OSError:
+                pass  # best-effort; may fail on some filesystems
+
             self._creds = TinyDB(str(creds_path))
+
+            # Lock down the file itself after TinyDB creates/opens it.
+            try:
+                os.chmod(str(creds_path), stat.S_IRUSR | stat.S_IWUSR)  # 0o600
+            except OSError:
+                pass  # best-effort
         return self._creds
 
     def set_debug(self, debug: bool):

--- a/esper/cli/state.py
+++ b/esper/cli/state.py
@@ -1,0 +1,89 @@
+"""
+Lightweight replacement for Cement's App object.
+All CLI modules import `state` from here instead of using `self.app`.
+"""
+import json
+import logging
+import os
+import sys
+from pathlib import Path
+
+import typer
+from tinydb import TinyDB
+
+from esper.ext.db_wrapper import DBWrapper
+
+CREDS_FILE = os.path.expanduser("~/.esper/db/creds.json")
+CERTS_FOLDER = os.path.expanduser("~/.esper/certs")
+
+
+class EsperState:
+    """Module-level singleton that replaces the Cement App context."""
+
+    def __init__(self):
+        self._creds = None
+        self.debug = False
+
+        # Cert paths (used by secureadb)
+        self.local_key = os.path.expanduser("~/.esper/certs/local.key")
+        self.local_cert = os.path.expanduser("~/.esper/certs/local.pem")
+        self.device_cert = os.path.expanduser("~/.esper/certs/device.pem")
+        self.certs_path = CERTS_FOLDER
+
+        # Logger
+        logging.basicConfig(
+            level=logging.WARNING,
+            format="%(levelname)s %(name)s: %(message)s",
+        )
+        self.log = logging.getLogger("espercli")
+
+    @property
+    def creds(self):
+        """Lazy-initialise TinyDB, creating parent dirs as needed."""
+        if self._creds is None:
+            creds_path = Path(CREDS_FILE)
+            creds_path.parent.mkdir(parents=True, exist_ok=True)
+            self._creds = TinyDB(str(creds_path))
+        return self._creds
+
+    def set_debug(self, debug: bool):
+        self.debug = debug
+        level = logging.DEBUG if debug else logging.WARNING
+        logging.getLogger("espercli").setLevel(level)
+
+
+# Single shared instance used by all command modules
+state = EsperState()
+
+
+# ---------------------------------------------------------------------------
+# Helpers that replace the Cement utility functions
+# ---------------------------------------------------------------------------
+
+def validate_creds():
+    """Exit 1 with a Rich error panel if credentials are not configured."""
+    db = DBWrapper(state.creds)
+    if not db.get_configure():
+        from rich.console import Console
+        from rich.panel import Panel
+        Console(stderr=True).print(
+            Panel(
+                "[bold red]✗[/bold red]  No credentials found.\n\n"
+                "[dim]Run [cyan]espercli configure[/cyan] to set your environment, "
+                "enterprise ID and API token.[/dim]",
+                title="[bold red]Not Configured[/bold red]",
+                border_style="red",
+                expand=False,
+                padding=(0, 1),
+            )
+        )
+        raise typer.Exit(1)
+
+
+def parse_error_message(exception) -> str:
+    """Extract a human-readable message from an ApiException."""
+    try:
+        body = json.loads(exception.body) if exception.body else {}
+        return body.get("message") or exception.reason
+    except (ValueError, AttributeError):
+        return getattr(exception, "reason", str(exception))

--- a/esper/cli/status.py
+++ b/esper/cli/status.py
@@ -1,0 +1,107 @@
+"""
+Device status commands — replaces esper/controllers/device/status.py.
+`espercli status latest`
+"""
+from ast import literal_eval
+from typing import Optional
+
+import typer
+from esperclient.rest import ApiException
+
+from esper.cli.output import render
+from esper.cli.state import state, validate_creds, parse_error_message
+from esper.controllers.enums import OutputFormat
+from esper.ext.api_client import APIClient
+from esper.ext.db_wrapper import DBWrapper
+
+app = typer.Typer(help="Device status commands")
+
+
+@app.command("latest")
+def status_latest(
+    device: Optional[str] = typer.Option(None, "--device", "-d", help="Device name"),
+    json_output: bool = typer.Option(False, "--json", "-j", help="Render result in JSON format"),
+):
+    """Show the latest device status."""
+    validate_creds()
+    db = DBWrapper(state.creds)
+    device_client = APIClient(db.get_configure()).get_device_api_client()
+    enterprise_id = db.get_enterprise_id()
+
+    if device:
+        try:
+            search_response = device_client.get_all_devices(
+                enterprise_id, limit=1, offset=0, name=device
+            )
+            if not search_response.results:
+                render(f"Device does not exist with name {device}")
+                raise typer.Exit(1)
+            device_id = search_response.results[0].id
+        except ApiException as e:
+            state.log.error(f"[status-latest] Failed to list devices: {e}")
+            render(f"ERROR: {parse_error_message(e)}")
+            raise typer.Exit(1)
+    else:
+        dev = db.get_device()
+        if not dev or not dev.get("id"):
+            render("There is no active device.")
+            raise typer.Exit(1)
+        device_id = dev.get("id")
+
+    try:
+        response = device_client.get_device_event(enterprise_id, device_id, latest_event=1)
+    except ApiException as e:
+        state.log.error(f"[status-latest] Failed to get device status: {e}")
+        render(f"ERROR: {parse_error_message(e)}")
+        raise typer.Exit(1)
+
+    battery_level = battery_temp = data_download = data_upload = None
+    memory_storage = memory_ram = link_speed = signal_strength = None
+
+    if response.results:
+        data = literal_eval(response.results[0].data)
+        pm = data.get("powerManagementEvent", {})
+        bs = pm.get("batteryStatus", {})
+        battery_level = bs.get("batteryLevel")
+        battery_temp = bs.get("batteryTemperature")
+
+        du = data.get("dataUsageStats", {})
+        data_download = du.get("totalDataDownload")
+        data_upload = du.get("totalDataUpload")
+
+        mem_events = data.get("memoryEvents", [])
+        if len(mem_events) > 1:
+            memory_storage = mem_events[1].get("countInMb")
+        if len(mem_events) > 0:
+            memory_ram = mem_events[0].get("countInMb")
+
+        net = data.get("networkEvent", {})
+        wifi = net.get("wifiNetworkInfo", {})
+        link_speed = wifi.get("linkSpeed")
+        signal_strength = wifi.get("signalStrength")
+
+    if not json_output:
+        title, details = "TITLE", "DETAILS"
+        renderable = [
+            {title: "battery_level", details: battery_level},
+            {title: "battery_temperature", details: battery_temp},
+            {title: "data_download", details: data_download},
+            {title: "data_upload", details: data_upload},
+            {title: "memory_storage", details: memory_storage},
+            {title: "memory_ram", details: memory_ram},
+            {title: "link_speed", details: link_speed},
+            {title: "signal_strength", details: signal_strength},
+        ]
+        render(renderable, format=OutputFormat.TABULATED.value, headers="keys", tablefmt="plain")
+    else:
+        renderable = {
+            "battery_level": battery_level,
+            "battery_temperature": battery_temp,
+            "data_download": data_download,
+            "data_upload": data_upload,
+            "memory_storage": memory_storage,
+            "memory_ram": memory_ram,
+            "link_speed": link_speed,
+            "signal_strength": signal_strength,
+        }
+        render(renderable, format=OutputFormat.JSON.value)

--- a/esper/cli/telemetry.py
+++ b/esper/cli/telemetry.py
@@ -1,0 +1,133 @@
+"""
+Telemetry commands — replaces esper/controllers/telemetry/telemetry.py.
+`espercli telemetry get-data`
+"""
+from datetime import datetime, timedelta
+from typing import Optional
+
+import requests
+import typer
+from esperclient.rest import ApiException
+
+from esper.cli.completions import device_name_complete, period_complete, statistic_complete
+from esper.cli.output import render
+from esper.cli.state import state, validate_creds, parse_error_message
+from esper.controllers.enums import OutputFormat
+from esper.ext.api_client import APIClient
+from esper.ext.db_wrapper import DBWrapper
+from esper.ext.telemetry_api import get_telemetry_url
+
+app = typer.Typer(help="Telemetry commands")
+
+
+@app.command("get-data")
+def telemetry_get_data(
+    device_name: Optional[str] = typer.Option(
+        None, "--device", "-d", help="Device name",
+        shell_complete=device_name_complete,
+    ),
+    metric: Optional[str] = typer.Option(None, "--metric", "-m", help="Metric name ({category}-{metric})"),
+    from_time: Optional[str] = typer.Option(
+        None, "--from", "-f", help="Start date-time (ISO format)"
+    ),
+    period: str = typer.Option(
+        "hour", "--period", "-p", help="Period: hour, month, or day",
+        shell_complete=period_complete,
+    ),
+    statistic: str = typer.Option(
+        "avg", "--statistic", "-s", help="Statistic: avg, sum, or count",
+        shell_complete=statistic_complete,
+    ),
+    last: Optional[str] = typer.Option(
+        None, "--last", "-l", help="Relative lookback (n hours/days based on period)"
+    ),
+    to_time: Optional[str] = typer.Option(
+        None, "--to", "-t", help="End date-time (ISO format)"
+    ),
+):
+    """Get telemetry data for a device."""
+    validate_creds()
+    db = DBWrapper(state.creds)
+    environment = db.get_configure().get("environment")
+    enterprise_id = db.get_enterprise_id()
+    api_key = db.get_configure().get("api_key")
+    device_client = APIClient(db.get_configure()).get_device_api_client()
+
+    if not device_name:
+        render("No device specified. Use the --device option to specify a device")
+        raise typer.Exit(1)
+
+    if not metric:
+        render("No metric specified. Use the --metric option (format: {category}-{metric})")
+        raise typer.Exit(1)
+
+    # Resolve device ID
+    try:
+        response = device_client.get_all_devices(enterprise_id, limit=1, offset=0, name=device_name)
+        if not response.results:
+            render(f"Device does not exist with name {device_name}")
+            raise typer.Exit(1)
+        device_id = response.results[0].id
+    except ApiException as e:
+        state.log.error(f"[telemetry-get-data] Failed to fetch device {device_name}: {e}")
+        render(f"ERROR: {parse_error_message(e)}")
+        raise typer.Exit(1)
+
+    # Compute from/to timestamps
+    now = datetime.now()
+    computed_from = datetime.fromisoformat(from_time) if from_time else (now - timedelta(days=2))
+    computed_to = datetime.fromisoformat(to_time) if to_time else now
+
+    if last:
+        n = int(last)
+        if period == "hour":
+            computed_from = now - timedelta(hours=n)
+        elif period == "day":
+            computed_from = now - timedelta(days=n)
+        else:
+            computed_from = now.replace(month=now.month - n)
+        computed_to = now
+
+    def _fmt_dt(dt) -> str:
+        s = str(dt).replace(" ", "T")
+        if "." not in s:
+            s += ".0000Z"
+        elif "Z" not in s:
+            s += "Z"
+        return s
+
+    from_str = _fmt_dt(computed_from)
+    to_str = _fmt_dt(computed_to)
+
+    if "-" not in metric:
+        render("ERROR: Metric must be of format {category}-{metric name}")
+        raise typer.Exit(1)
+
+    category, metric_name = metric.split("-", 1)
+
+    url = get_telemetry_url(
+        environment, enterprise_id, device_id,
+        category, metric_name, from_str, to_str, period, statistic,
+    )
+
+    api_response = requests.get(url, headers={"Authorization": f"Bearer {api_key}"})
+    response_json = api_response.json()
+
+    if api_response.status_code != 200:
+        if response_json.get("meta", {}).get("non_field_errors"):
+            render(f"ERRORS: {response_json['meta']['non_field_errors']}")
+        elif response_json.get("errors"):
+            render(f"ERRORS: {response_json['errors']}")
+        else:
+            render("ERROR: Unknown error occurred")
+        raise typer.Exit(1)
+
+    data = response_json.get("data", {})
+    render_data = [{"Time": d["x"], "Value": d["y"]} for d in data]
+
+    if not render_data:
+        render(f"No telemetry data for device {device_name} found between time range")
+        raise typer.Exit(0)
+
+    render(f"Telemetry data for device {device_name}")
+    render(render_data, format=OutputFormat.TABULATED.value, headers="keys", tablefmt="plain")

--- a/esper/cli/token.py
+++ b/esper/cli/token.py
@@ -35,7 +35,7 @@ def _token_basic_response(token, fmt=OutputFormat.TABULATED):
         "Enterprise": token.enterprise,
         "Developer App": token.developer_app,
         "Token": token.token,
-        "Expires On": token.scope,
+        "Expires On": token.expires_on,
         "Created On": str(token.created_on),
         "Updated On": str(token.updated_on),
     }

--- a/esper/cli/token.py
+++ b/esper/cli/token.py
@@ -1,0 +1,129 @@
+"""
+Token commands — replaces esper/controllers/token/token.py.
+`espercli token show/renew`
+"""
+from typing import Optional
+
+import typer
+from esperclient.rest import ApiException
+
+from esper.cli.output import render
+from esper.cli.state import state, validate_creds, parse_error_message
+from esper.controllers.enums import OutputFormat
+from esper.ext.api_client import APIClient
+from esper.ext.db_wrapper import DBWrapper
+
+app = typer.Typer(help="Token commands")
+
+
+# ---------------------------------------------------------------------------
+# Shared helpers
+# ---------------------------------------------------------------------------
+
+def _token_basic_response(token, fmt=OutputFormat.TABULATED):
+    if fmt == OutputFormat.TABULATED:
+        title, details = "TITLE", "DETAILS"
+        return [
+            {title: "Enterprise Id", details: token.enterprise},
+            {title: "Token", details: token.token},
+            {title: "Expires On", details: token.expires_on},
+            {title: "Scope", details: token.scope},
+            {title: "Created On", details: token.created_on},
+            {title: "Updated On", details: token.updated_on},
+        ]
+    return {
+        "Enterprise": token.enterprise,
+        "Developer App": token.developer_app,
+        "Token": token.token,
+        "Expires On": token.scope,
+        "Created On": str(token.created_on),
+        "Updated On": str(token.updated_on),
+    }
+
+
+def _renew_token_basic_response(token, fmt=OutputFormat.TABULATED):
+    enterprise_id = token.enterprise.split("[")[1].split("]")[0]
+    developer_app = token.developerapp.split("(")[1].split(")")[0]
+    if fmt == OutputFormat.TABULATED:
+        title, details = "TITLE", "DETAILS"
+        return [
+            {title: "Id", details: token.id},
+            {title: "User", details: token.user},
+            {title: "Enterprise Id", details: enterprise_id},
+            {title: "Developer App", details: developer_app},
+            {title: "Token", details: token.token},
+            {title: "Scope", details: token.scope},
+            {title: "Created On", details: token.created_on},
+            {title: "Updated On", details: token.updated_on},
+            {title: "Expires On", details: token.expires_at},
+        ]
+    return {
+        "Id": token.id,
+        "User": token.user,
+        "Enterprise Id": enterprise_id,
+        "Developer App": developer_app,
+        "Token": token.token,
+        "Scope": token.scope,
+        "Created On": str(token.created_on),
+        "Updated On": str(token.updated_on),
+        "Expires On": str(token.expires_at),
+    }
+
+
+# ---------------------------------------------------------------------------
+# Commands
+# ---------------------------------------------------------------------------
+
+@app.command("show")
+def token_show(
+    json_output: bool = typer.Option(False, "--json", "-j", help="Render result in JSON format"),
+):
+    """Show token details."""
+    validate_creds()
+    db = DBWrapper(state.creds)
+    token_client = APIClient(db.get_configure()).get_token_api_client()
+
+    try:
+        response = token_client.get_token_info()
+    except ApiException as e:
+        state.log.error(f"[token-show] Failed to show token details: {e}")
+        render(f"ERROR: {parse_error_message(e)}")
+        raise typer.Exit(1)
+
+    if not json_output:
+        render(_token_basic_response(response), format=OutputFormat.TABULATED.value, headers="keys", tablefmt="plain")
+    else:
+        render(_token_basic_response(response, OutputFormat.JSON), format=OutputFormat.JSON.value)
+
+
+@app.command("renew")
+def token_renew(
+    dev_app_id: Optional[str] = typer.Option(None, "--developerappid", "-d", help="Developer App ID"),
+    token: Optional[str] = typer.Option(None, "--token", "-t", help="Token to renew"),
+    json_output: bool = typer.Option(False, "--json", "-j", help="Render result in JSON format"),
+):
+    """Renew a token."""
+    validate_creds()
+    db = DBWrapper(state.creds)
+    token_client = APIClient(db.get_configure()).get_token_api_client()
+    enterprise_id = db.get_enterprise_id()
+
+    if not token:
+        render("There is no token given to renew.")
+        raise typer.Exit(1)
+
+    if not dev_app_id:
+        render("DeveloperApp id is not given.")
+        raise typer.Exit(1)
+
+    try:
+        response = token_client.renew_token(enterprise_id, dev_app_id, token)
+    except ApiException as e:
+        state.log.error(f"[token-renew] Failed to renew token: {e}")
+        render(f"ERROR: {parse_error_message(e)}")
+        raise typer.Exit(1)
+
+    if not json_output:
+        render(_renew_token_basic_response(response), format=OutputFormat.TABULATED.value, headers="keys", tablefmt="plain")
+    else:
+        render(_renew_token_basic_response(response, OutputFormat.JSON), format=OutputFormat.JSON.value)

--- a/esper/cli/user.py
+++ b/esper/cli/user.py
@@ -1,0 +1,118 @@
+# User management commands — list, invite, and remove enterprise users.
+from typing import Optional
+
+import typer
+
+from esper.cli.output import render
+from esper.cli.state import state, validate_creds
+from esper.controllers.enums import OutputFormat
+from esper.ext.api_rest import api_delete, api_get, api_post
+from esper.ext.db_wrapper import DBWrapper
+
+app = typer.Typer(help="User management commands")
+
+_DEVICE_USER_PREFIX = "device-"
+_DEVICE_USER_DOMAIN = "@esper.io"
+
+
+def _is_system_user(email: str) -> bool:
+    return email.startswith(_DEVICE_USER_PREFIX) and email.endswith(_DEVICE_USER_DOMAIN)
+
+
+@app.command("list")
+def user_list(
+    as_json: bool = typer.Option(False, "--json", "-j", help="Output as JSON"),
+) -> None:
+    """List all enterprise users (excluding device system accounts)."""
+    validate_creds()
+    db = DBWrapper(state.creds)
+    cfg = db.get_configure()
+    environment = cfg.get("environment")
+    api_key = cfg.get("api_key")
+    eid = db.get_enterprise_id()
+
+    try:
+        data = api_get(environment, api_key, "/authn2/v1/users/")
+    except Exception as e:
+        render(f"ERROR: {e}")
+        raise typer.Exit(1)
+
+    content = data.get("content", data)
+    users = content.get("results", []) if isinstance(content, dict) else []
+    users = [u for u in users if not _is_system_user(u.get("email", ""))]
+
+    if not users:
+        render("No users found.")
+        raise typer.Exit(0)
+
+    if as_json:
+        render(users, format=OutputFormat.JSON.value)
+        return
+
+    rows = [
+        {
+            "USER ID": u.get("user_id", "")[:8],
+            "EMAIL": u.get("email", "—"),
+            "NAME": u.get("name", "—"),
+            "CREATED AT": u.get("created_at", "—"),
+        }
+        for u in users
+    ]
+    render(rows, format=OutputFormat.TABULATED.value, headers="keys", tablefmt="plain")
+
+
+@app.command("invite")
+def user_invite(
+    email: str = typer.Option(..., "--email", "-e", help="Email address to invite"),
+    role: str = typer.Option("viewer", "--role", "-r", help="Role to assign (default: viewer)"),
+    as_json: bool = typer.Option(False, "--json", "-j", help="Output as JSON"),
+) -> None:
+    """Invite a user to the enterprise."""
+    validate_creds()
+    db = DBWrapper(state.creds)
+    cfg = db.get_configure()
+    environment = cfg.get("environment")
+    api_key = cfg.get("api_key")
+    eid = db.get_enterprise_id()
+
+    try:
+        result = api_post(environment, api_key, f"/authn2/v0/tenant/{eid}/invite", {"email": email, "role": role})
+    except Exception as e:
+        render(f"ERROR: {e}")
+        raise typer.Exit(1)
+
+    if as_json:
+        render(result, format=OutputFormat.JSON.value)
+        return
+
+    render(f"Invited {email} with role '{role}'")
+
+
+@app.command("remove")
+def user_remove(
+    user_id: str = typer.Argument(..., help="User ID to remove"),
+    yes: bool = typer.Option(False, "--yes", "-y", help="Skip confirmation prompt"),
+) -> None:
+    """Remove a user from the enterprise."""
+    validate_creds()
+
+    if not yes:
+        typer.confirm(f"Remove user {user_id}?", abort=True)
+
+    db = DBWrapper(state.creds)
+    cfg = db.get_configure()
+    environment = cfg.get("environment")
+    api_key = cfg.get("api_key")
+    eid = db.get_enterprise_id()
+
+    try:
+        status = api_delete(environment, api_key, f"/authn2/v0/tenant/{eid}/user/{user_id}/")
+    except Exception as e:
+        render(f"ERROR: {e}")
+        raise typer.Exit(1)
+
+    if status in (200, 204):
+        render(f"Removed user {user_id}")
+    else:
+        render(f"ERROR: Unexpected status code {status}")
+        raise typer.Exit(1)

--- a/esper/cli/version.py
+++ b/esper/cli/version.py
@@ -1,0 +1,283 @@
+"""
+Application version commands — replaces esper/controllers/application/version.py.
+`espercli version list/show/delete/devices`
+"""
+from http import HTTPStatus
+from typing import Optional
+
+import typer
+from esperclient.rest import ApiException
+
+from esper.cli.completions import app_name_complete, legacy_format_complete
+from esper.cli.output import render
+from esper.cli.state import state, validate_creds, parse_error_message
+from esper.controllers.enums import OutputFormat
+from esper.ext.api_client import APIClient
+from esper.ext.db_wrapper import DBWrapper
+
+app = typer.Typer(help="Application version commands")
+
+
+# ---------------------------------------------------------------------------
+# Shared helpers
+# ---------------------------------------------------------------------------
+
+def _get_application_id(db, application_arg: Optional[str], tag: str) -> str:
+    if application_arg:
+        return application_arg
+    active = db.get_application()
+    if not active or not active.get("id"):
+        render("There is no active application.")
+        raise typer.Exit(1)
+    return active.get("id")
+
+
+def _version_basic_response(version, fmt=OutputFormat.TABULATED, legacy_format=True):
+    valid_keys = ["id", "version_code", "version_name", "build_number", "size_in_mb", "release_track"]
+
+    if fmt == OutputFormat.JSON:
+        renderable = {k: v for k, v in version.to_dict().items() if k in valid_keys}
+        renderable["installed_count"] = version.installed_count or 0
+    else:
+        title, details = "TITLE", "DETAILS"
+        if legacy_format:
+            filtered = {k: v for k, v in version.to_dict().items()
+                        if k in valid_keys and k != "version_name"}
+        else:
+            filtered = {k: v for k, v in version.to_dict().items()
+                        if k in valid_keys and k != "build_number"}
+        renderable = [{title: k, details: v} for k, v in filtered.items()]
+        renderable.append({title: "installed_count", details: version.installed_count or 0})
+    return renderable
+
+
+# ---------------------------------------------------------------------------
+# Commands
+# ---------------------------------------------------------------------------
+
+@app.command("list")
+def version_list(
+    application: Optional[str] = typer.Option(
+        None, "--app", "-a", help="Application ID (default: active application)",
+        shell_complete=app_name_complete,
+    ),
+    version_code: Optional[str] = typer.Option(None, "--code", "-c", help="Version code filter"),
+    build_number: Optional[str] = typer.Option(None, "--number", "-n", help="Build number filter"),
+    legacy_format: str = typer.Option(
+        "true", "--legacy-format", "-lf", help="Use legacy format [true/false]",
+        shell_complete=legacy_format_complete,
+    ),
+    limit: int = typer.Option(20, "--limit", "-l", help="Results per page"),
+    offset: int = typer.Option(0, "--offset", "-i", help="Initial index"),
+    json_output: bool = typer.Option(False, "--json", "-j", help="Render result in JSON format"),
+):
+    """List application versions."""
+    validate_creds()
+    db = DBWrapper(state.creds)
+    application_client = APIClient(db.get_configure()).get_application_api_client()
+    enterprise_id = db.get_enterprise_id()
+
+    application_id = _get_application_id(db, application, "version-list")
+    use_legacy = legacy_format.lower() == "true"
+
+    kwargs = {}
+    if version_code:
+        kwargs["version_code"] = version_code
+    if build_number:
+        kwargs["build_number"] = build_number
+
+    try:
+        response = application_client.get_app_versions(
+            application_id, enterprise_id, limit=limit, offset=offset,
+            legacy_format=use_legacy, **kwargs
+        )
+    except ApiException as e:
+        state.log.error(f"[version-list] Failed to list versions: {e}")
+        render(f"ERROR: {parse_error_message(e)}")
+        raise typer.Exit(1)
+
+    render(f"Total Number of Versions: {response.count}")
+    if not json_output:
+        if use_legacy:
+            label = {"id": "ID", "version_code": "VERSION CODE", "build_number": "BUILD NUMBER",
+                     "size_in_mb": "SIZE IN MB", "release_track": "RELEASE TRACK",
+                     "installed_count": "INSTALLED COUNT"}
+        else:
+            label = {"id": "ID", "version_name": "VERSION NAME", "version_code": "VERSION CODE",
+                     "size_in_mb": "SIZE IN MB", "release_track": "RELEASE TRACK",
+                     "installed_count": "INSTALLED COUNT"}
+
+        versions = []
+        for v in response.results:
+            if use_legacy:
+                row = {
+                    label["id"]: v.id,
+                    label["version_code"]: v.version_code,
+                    label["build_number"]: getattr(v, "build_number", "") or "",
+                    label["size_in_mb"]: v.size_in_mb,
+                    label["release_track"]: v.release_track,
+                    label["installed_count"]: v.installed_count or 0,
+                }
+            else:
+                row = {
+                    label["id"]: v.id,
+                    label["version_name"]: getattr(v, "version_name", "") or "",
+                    label["version_code"]: v.version_code,
+                    label["size_in_mb"]: v.size_in_mb,
+                    label["release_track"]: v.release_track,
+                    label["installed_count"]: v.installed_count or 0,
+                }
+            versions.append(row)
+        render(versions, format=OutputFormat.TABULATED.value, headers="keys", tablefmt="plain")
+    else:
+        versions = []
+        for v in response.results:
+            if use_legacy:
+                row = {
+                    "id": v.id, "version_code": v.version_code,
+                    "build_number": getattr(v, "build_number", None),
+                    "size_in_mb": v.size_in_mb, "release_track": v.release_track,
+                    "installed_count": v.installed_count or 0,
+                }
+            else:
+                row = {
+                    "id": v.id,
+                    "version_name": getattr(v, "version_name", None),
+                    "version_code": v.version_code,
+                    "size_in_mb": v.size_in_mb, "release_track": v.release_track,
+                    "installed_count": v.installed_count or 0,
+                }
+            versions.append(row)
+        render(versions, format=OutputFormat.JSON.value)
+
+
+@app.command("show")
+def version_show(
+    version_id: str = typer.Argument(..., help="Version ID"),
+    application: Optional[str] = typer.Option(
+        None, "--app", "-a", help="Application ID (default: active application)",
+        shell_complete=app_name_complete,
+    ),
+    legacy_format: str = typer.Option(
+        "true", "--legacy-format", "-lf", help="Use legacy format [true/false]",
+        shell_complete=legacy_format_complete,
+    ),
+    json_output: bool = typer.Option(False, "--json", "-j", help="Render result in JSON format"),
+):
+    """Show application version details."""
+    validate_creds()
+    db = DBWrapper(state.creds)
+    application_client = APIClient(db.get_configure()).get_application_api_client()
+    enterprise_id = db.get_enterprise_id()
+
+    application_id = _get_application_id(db, application, "version-show")
+    use_legacy = legacy_format.lower() == "true"
+
+    try:
+        response = application_client.get_app_version(
+            version_id, application_id, enterprise_id, legacy_format=use_legacy
+        )
+    except ApiException as e:
+        state.log.error(f"[version-show] Failed to show version: {e}")
+        render(f"ERROR: {parse_error_message(e)}")
+        raise typer.Exit(1)
+
+    if not json_output:
+        render(_version_basic_response(response, fmt=OutputFormat.TABULATED, legacy_format=use_legacy),
+               format=OutputFormat.TABULATED.value, headers="keys", tablefmt="plain")
+    else:
+        render(_version_basic_response(response, fmt=OutputFormat.JSON, legacy_format=use_legacy),
+               format=OutputFormat.JSON.value)
+
+
+@app.command("delete")
+def version_delete(
+    version_id: str = typer.Argument(..., help="Version ID to delete"),
+    application: Optional[str] = typer.Option(
+        None, "--app", "-a", help="Application ID (default: active application)",
+        shell_complete=app_name_complete,
+    ),
+    yes: bool = typer.Option(False, "--yes", "-y", help="Skip confirmation prompt"),
+):
+    """Delete an application version."""
+    if not yes:
+        typer.confirm(f"Delete version {version_id}? This cannot be undone.", abort=True)
+    validate_creds()
+    db = DBWrapper(state.creds)
+    application_client = APIClient(db.get_configure()).get_application_api_client()
+    enterprise_id = db.get_enterprise_id()
+
+    application_id = _get_application_id(db, application, "version-delete")
+
+    try:
+        application_client.delete_app_version(version_id, application_id, enterprise_id)
+        render(f"Version with id {version_id} deleted successfully")
+    except ApiException as e:
+        state.log.error(f"[version-delete] Failed to delete version: {e}")
+        render(f"ERROR: {parse_error_message(e)}")
+        raise typer.Exit(1)
+
+    # Unset active application if it was deleted
+    try:
+        application_client.get_application(application_id, enterprise_id)
+    except ApiException as e:
+        if e.status == HTTPStatus.NOT_FOUND:
+            active_app = db.get_application()
+            if active_app and active_app.get("id") == application_id:
+                db.unset_application()
+
+
+@app.command("devices")
+def version_devices(
+    version_id: str = typer.Argument(..., help="Version ID"),
+    application: Optional[str] = typer.Option(
+        None, "--app", "-a", help="Application ID (default: active application)",
+        shell_complete=app_name_complete,
+    ),
+    search: Optional[str] = typer.Option(None, "--search", "-s", help="Search term"),
+    limit: int = typer.Option(20, "--limit", "-l", help="Results per page"),
+    offset: int = typer.Option(0, "--offset", "-o", help="Initial index"),
+    json_output: bool = typer.Option(False, "--json", "-j", help="Render result in JSON format"),
+):
+    """List devices with this application version installed."""
+    validate_creds()
+    db = DBWrapper(state.creds)
+    application_client = APIClient(db.get_configure()).get_application_api_client()
+    enterprise_id = db.get_enterprise_id()
+
+    application_id = _get_application_id(db, application, "version-devices")
+
+    kwargs = {}
+    if search:
+        kwargs["search"] = search
+
+    try:
+        response = application_client.get_install_devices(
+            version_id, application_id, enterprise_id, limit=limit, offset=offset, **kwargs
+        )
+    except ApiException as e:
+        state.log.error(f"[version-devices] Failed to list devices: {e}")
+        render(f"ERROR: {parse_error_message(e)}")
+        raise typer.Exit(1)
+
+    render(f"Total Number of Devices: {response.count}")
+    if not json_output:
+        label = {"id": "ID", "device_name": "DEVICE NAME",
+                 "alias_name": "ALIAS NAME", "group_name": "GROUP NAME"}
+        devices = [
+            {
+                label["id"]: d.id,
+                label["device_name"]: d.device_name,
+                label["alias_name"]: d.alias_name,
+                label["group_name"]: d.group_name,
+            }
+            for d in response.results
+        ]
+        render(devices, format=OutputFormat.TABULATED.value, headers="keys", tablefmt="plain")
+    else:
+        devices = [
+            {"id": d.id, "device_name": d.device_name,
+             "alias_name": d.alias_name, "group_name": d.group_name}
+            for d in response.results
+        ]
+        render(devices, format=OutputFormat.JSON.value)

--- a/esper/ext/api_rest.py
+++ b/esper/ext/api_rest.py
@@ -2,6 +2,34 @@
 import requests
 
 
+def api_get_all(environment: str, api_key: str, path: str, page_size: int = 100, **params) -> list:
+    """Fetch every page from a paginated REST endpoint and return all results.
+
+    The endpoint must return a JSON object with ``results`` (list) and
+    ``count`` (int) keys — the standard Esper pagination envelope.
+    """
+    url = f"https://{environment}-api.esper.cloud/api{path}"
+    headers = {"Authorization": f"Bearer {api_key}"}
+    all_items: list = []
+    offset = 0
+    while True:
+        resp = requests.get(
+            url,
+            headers=headers,
+            params={**params, "limit": page_size, "offset": offset},
+            timeout=10,
+        )
+        resp.raise_for_status()
+        data = resp.json()
+        page = data.get("results", data.get("content", []))
+        all_items.extend(page)
+        total = data.get("count", 0)
+        if not page or len(all_items) >= total:
+            break
+        offset += page_size
+    return all_items
+
+
 def api_get(environment: str, api_key: str, path: str, **params) -> dict:
     url = f"https://{environment}-api.esper.cloud/api{path}"
     resp = requests.get(url, headers={"Authorization": f"Bearer {api_key}"}, params=params, timeout=10)

--- a/esper/ext/api_rest.py
+++ b/esper/ext/api_rest.py
@@ -1,0 +1,27 @@
+# Thin helpers for direct REST calls not covered by the esperclient SDK.
+import requests
+
+
+def api_get(environment: str, api_key: str, path: str, **params) -> dict:
+    url = f"https://{environment}-api.esper.cloud/api{path}"
+    resp = requests.get(url, headers={"Authorization": f"Bearer {api_key}"}, params=params, timeout=10)
+    resp.raise_for_status()
+    return resp.json()
+
+
+def api_post(environment: str, api_key: str, path: str, body: dict) -> dict:
+    url = f"https://{environment}-api.esper.cloud/api{path}"
+    resp = requests.post(
+        url,
+        headers={"Authorization": f"Bearer {api_key}", "Content-Type": "application/json"},
+        json=body,
+        timeout=10,
+    )
+    resp.raise_for_status()
+    return resp.json()
+
+
+def api_delete(environment: str, api_key: str, path: str) -> int:
+    url = f"https://{environment}-api.esper.cloud/api{path}"
+    resp = requests.delete(url, headers={"Authorization": f"Bearer {api_key}"}, timeout=10)
+    return resp.status_code

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,3 @@
-cement==3.0.2
-clint==0.5.1
-colorlog==4.0.2
-crayons==0.2.0
 esperclient==0.1.3
 jinja2==3.1.6
 pyyaml==6.0.1
@@ -11,6 +7,9 @@ tinydb==3.13.0
 tqdm==4.66.3
 markupsafe==2.0.1
 cryptography==44.0.1
+typer>=0.9.0
+rich>=13.0.0
+urllib3<2
 
 # For Secure ADB
 pyOpenSSL==24.1.0

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ setup(
     include_package_data=True,
     entry_points="""
         [console_scripts]
-        espercli = esper.main:main
+        espercli = esper.cli.app:main_entry
     """,
     install_requires=[
         'pip==23.3',
@@ -36,9 +36,12 @@ setup(
         'jinja2>=2.10.1',
         'pyyaml>=5.4',
         'requests==2.32.2',
+        'urllib3<2',
         'tabulate>=0.8.3',
         'tinydb>=3.13.0',
         'tqdm>=4.32.1',
+        'typer>=0.9.0',
+        'rich>=13.0.0',
         'pyOpenSSL==24.1.0'
     ],
 )

--- a/setup.py
+++ b/setup.py
@@ -26,22 +26,17 @@ setup(
         espercli = esper.cli.app:main_entry
     """,
     install_requires=[
-        'pip==23.3',
-        'wheel',
-        'cement==3.0.2',
-        'clint>=0.5.1',
-        'colorlog>=4.0.2',
-        'crayons>=0.2.0',
         'esperclient>=0.1.3',
         'jinja2>=2.10.1',
         'pyyaml>=5.4',
-        'requests==2.32.2',
+        'requests>=2.32.0',
         'urllib3<2',
         'tabulate>=0.8.3',
         'tinydb>=3.13.0',
         'tqdm>=4.32.1',
         'typer>=0.9.0',
         'rich>=13.0.0',
-        'pyOpenSSL==24.1.0'
+        'cryptography>=44.0.1',
+        'pyOpenSSL>=24.1.0',
     ],
 )


### PR DESCRIPTION
## Summary

Complete rewrite of the CLI layer replacing the Cement framework with [Typer](https://typer.tiangolo.com) + [Rich](https://github.com/Textualize/rich), while keeping full command parity with the original. All existing commands work identically from the user's perspective — the change is entirely in the implementation and UX.

### What changed

**Framework migration**
- All 20+ command domains ported to Typer (`device`, `app`, `group`, `pipeline`, `commandsV2`, `secureadb`, `telemetry`, `content`, `token`, `configure`, `enterprise`, `status`, `installs`, `version`, `device-command`, `group-command`, `stage`, `operation`, `execute`, `token`)
- New entry point: `esper/cli/app.py` wires all sub-apps and the pipeline nesting hierarchy
- `setup.py` updated with new dependencies (`typer>=0.9.0`, `rich>=13.0.0`, `urllib3<2`)

**Rich output**
- Colour-coded device/command states (`ACTIVE` → green, `INACTIVE` → yellow, `FAILURE` → red, etc.)
- Tables with underlined headers instead of plain text
- Syntax-highlighted JSON output (`--json` flag)
- Success messages with `✓` prefix; errors route to stderr in red

**Tab completion**
- `espercli completion <shell>` command — installs shell completion for zsh/bash/fish/powershell without requiring `shellingham` detection (bypasses the common "Shell None is not supported" failure)
- Static completions for all enum values: device states, command names, schedule types, days, time types, legacy-format, etc.
- Dynamic API-backed completions for device names, group names, and application IDs (fail silently if unconfigured)

**Error messages**
- On any usage error (typo, missing argument, unknown option), the relevant help page is shown inline immediately below the error panel — no need to re-run with `--help`
- Error panels point to the deepest relevant command path (`espercli device show --help`, not just `espercli --help`)
- `validate_creds()` shows a Rich panel with a direct pointer to `espercli configure` when credentials are missing

**Quality-of-life**
- `--all` / `-A` flag on `device list`, `app list`, `group list` — auto-paginates with a spinner
- `--yes` / `-y` flag on all destructive operations (wipe, delete) with confirmation prompt
- Global `--verbose` / `-v` and `--no-color` flags
- `espercli context` command — shows active environment, enterprise, device, app, group in a Rich panel
- `espercli about` command — shows CLI version
- Retry utility (`esper/cli/retry.py`) with exponential backoff for transient 5xx / connection errors

**Claude Code skill**
- `.claude/commands/esper.md` — a project-level Claude Code slash command providing a natural-language interface to the fleet. Users can type `/esper reboot the warehouse group` or `/esper show inactive devices` directly in Claude Code without remembering CLI syntax.

**Docs**
- README fully rewritten to reflect the new CLI (was 2,452 lines of Cement-era option tables; now 250 lines of real examples)

## Test plan

- [ ] `espercli configure` — set credentials
- [ ] `espercli context` — verify active context displays correctly
- [ ] `espercli device list` — tabulated output with colour-coded states
- [ ] `espercli device list --all` — auto-pagination spinner
- [ ] `espercli device list --json | jq length` — JSON output
- [ ] `espercli device show <name> --active` — sets active device
- [ ] `espercli device-command reboot` — fires command at active device
- [ ] `espercli device-command wipe` — prompts for confirmation
- [ ] `espercli app list --all` — auto-pagination
- [ ] `espercli version list` — uses active application
- [ ] `espercli group list` / `group devices` / `group-command reboot`
- [ ] `espercli commandsV2 list` / `commandsV2 command`
- [ ] `espercli completion zsh` — installs completion script
- [ ] Tab-complete: `espercli device list --state <TAB>` → enum values
- [ ] Tab-complete: `espercli device show <TAB>` → live device names
- [ ] `espercli devce` → error panel + full command list inline
- [ ] `espercli device show` (no arg) → error panel + usage inline
- [ ] `espercli --no-color device list` — strips ANSI
- [ ] `/esper` Claude Code skill (if Claude Code is available)

🤖 Generated with [Claude Code](https://claude.ai/claude-code)