### PR TITLE
Fix legacy install URLs and request timeouts

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,13 +20,13 @@ Also ships a **Claude Code skill** (`/esper`) so you can manage your fleet in pl
 **Recommended — pipx** (isolated, no venv management needed):
 
 ```sh
-pipx install git+https://github.com/avidan/esper-cli.git
+pipx install git+https://github.com/esper-io/esper-cli.git
 ```
 
 **From source:**
 
 ```sh
-git clone https://github.com/avidan/esper-cli.git
+git clone https://github.com/esper-io/esper-cli.git
 cd esper-cli
 pipx install -e .
 ```
@@ -34,7 +34,7 @@ pipx install -e .
 **Plain pip** (inside a virtualenv):
 
 ```sh
-pip install git+https://github.com/avidan/esper-cli.git
+pip install git+https://github.com/esper-io/esper-cli.git
 ```
 
 ---

--- a/esper/cli/application.py
+++ b/esper/cli/application.py
@@ -241,7 +241,7 @@ def app_download(
     url = response.app_file
     file_size = int(response.size_in_mb * 1024 * 1024)
     pbar = tqdm(total=file_size, initial=0, unit="B", unit_scale=True, desc="Downloading......")
-    req = requests.get(url, stream=True)
+    req = requests.get(url, stream=True, timeout=30)
     with open(dest, "ab") as f:
         for chunk in req.iter_content(chunk_size=1024):
             if chunk:

--- a/esper/cli/telemetry.py
+++ b/esper/cli/telemetry.py
@@ -110,7 +110,7 @@ def telemetry_get_data(
         category, metric_name, from_str, to_str, period, statistic,
     )
 
-    api_response = requests.get(url, headers={"Authorization": f"Bearer {api_key}"})
+    api_response = requests.get(url, headers={"Authorization": f"Bearer {api_key}"}, timeout=30)
     response_json = api_response.json()
 
     if api_response.status_code != 200:


### PR DESCRIPTION
## Summary

- Updates README install and clone URLs to `esper-io/esper-cli`.
- Adds a 30-second timeout to the telemetry GET request.
- Adds a 30-second timeout to streamed application downloads.

## Verification

- `python3 -m compileall -q esper`
- `git diff --check`

The legacy test suite was not run because it requires live Esper credentials and makes API calls.
